### PR TITLE
Remove deprecated theme usage 

### DIFF
--- a/fivekmrun_app_flutter/lib/charts/best_times_by_route_chart.dart
+++ b/fivekmrun_app_flutter/lib/charts/best_times_by_route_chart.dart
@@ -28,7 +28,7 @@ class BestTimesByRouteChart extends StatelessWidget {
           children: <Widget>[
             IntrinsicHeight(
                 child: Text("Рекорди по същински трасета",
-                    style: theme.textTheme.subtitle1)),
+                    style: theme.textTheme.titleSmall)),
             Expanded(
                 child: charts.BarChart(seriesList,
                     animate: this.animate,

--- a/fivekmrun_app_flutter/lib/charts/runs_by_route_chart.dart
+++ b/fivekmrun_app_flutter/lib/charts/runs_by_route_chart.dart
@@ -19,7 +19,7 @@ class RunsByRouteChart extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final subTitleStyle = theme.textTheme.subtitle1;
+    final subTitleStyle = theme.textTheme.titleSmall;
 
     return Padding(
         padding: EdgeInsets.all(8.0),

--- a/fivekmrun_app_flutter/lib/charts/runs_chart.dart
+++ b/fivekmrun_app_flutter/lib/charts/runs_chart.dart
@@ -59,7 +59,7 @@ class _RunsChartState extends State<RunsChart> {
                     "Тенденция от последните " +
                         this.widget.runs.length.toString() +
                         " бягания",
-                    style: theme.textTheme.subtitle1)),
+                    style: theme.textTheme.titleSmall)),
             IntrinsicHeight(child: Text(this.dataPointLabel)),
             Expanded(
               child: charts.TimeSeriesChart(

--- a/fivekmrun_app_flutter/lib/common/list_tile_row.dart
+++ b/fivekmrun_app_flutter/lib/common/list_tile_row.dart
@@ -16,7 +16,8 @@ class ListTileRow extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final color = this.iconColor != null ? this.iconColor : theme.colorScheme.secondary;
+    final color =
+        this.iconColor != null ? this.iconColor : theme.colorScheme.secondary;
     return Row(
       children: <Widget>[
         Padding(
@@ -30,7 +31,7 @@ class ListTileRow extends StatelessWidget {
         Expanded(
           child: Padding(
             padding: const EdgeInsets.all(8),
-            child: Text(text, style: theme.textTheme.subtitle2),
+            child: Text(text, style: theme.textTheme.titleSmall),
           ),
         ),
       ],

--- a/fivekmrun_app_flutter/lib/common/milestone_gauge.dart
+++ b/fivekmrun_app_flutter/lib/common/milestone_gauge.dart
@@ -32,7 +32,7 @@ class MilestoneGauge extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.center,
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
-                Text(value.toString(), style: textStyle.headline6),
+                Text(value.toString(), style: textStyle.titleLarge),
                 Text(milestone.toString(), style: textStyle.titleSmall),
               ],
             ),

--- a/fivekmrun_app_flutter/lib/common/milestone_gauge.dart
+++ b/fivekmrun_app_flutter/lib/common/milestone_gauge.dart
@@ -33,7 +33,7 @@ class MilestoneGauge extends StatelessWidget {
               crossAxisAlignment: CrossAxisAlignment.center,
               children: <Widget>[
                 Text(value.toString(), style: textStyle.headline6),
-                Text(milestone.toString(), style: textStyle.subtitle2),
+                Text(milestone.toString(), style: textStyle.titleSmall),
               ],
             ),
           ),

--- a/fivekmrun_app_flutter/lib/common/run_card.dart
+++ b/fivekmrun_app_flutter/lib/common/run_card.dart
@@ -15,8 +15,8 @@ class RunCard extends StatelessWidget {
     final theme = Theme.of(context);
     final iconColor = theme.colorScheme.secondary;
     final textTheme = theme.textTheme;
-    final labelStyle = theme.textTheme.bodyText2;
-    final valueStyle = theme.textTheme.bodyText1;
+    final labelStyle = theme.textTheme.bodyMedium;
+    final valueStyle = theme.textTheme.bodyLarge;
 
     return GestureDetector(
       onTap: () {
@@ -30,7 +30,7 @@ class RunCard extends StatelessWidget {
           padding: const EdgeInsets.all(8.0),
           child: Column(
             children: <Widget>[
-              Text(title, style: textTheme.subtitle1),
+              Text(title, style: textTheme.titleSmall),
               Row(
                   crossAxisAlignment: CrossAxisAlignment.center,
                   children: <Widget>[
@@ -42,9 +42,9 @@ class RunCard extends StatelessWidget {
                         children: <Widget>[
                           Text(
                             run.position.toString(),
-                            style: textTheme.headline6?.copyWith(
-                                color: theme
-                                    .colorScheme.secondary), //HACK: hide the label if Selfie but bump the space
+                            style: textTheme.titleLarge?.copyWith(
+                                color: theme.colorScheme
+                                    .secondary), //HACK: hide the label if Selfie but bump the space
                           ),
                           Text("място", style: labelStyle),
                         ],

--- a/fivekmrun_app_flutter/lib/common/select_button.dart
+++ b/fivekmrun_app_flutter/lib/common/select_button.dart
@@ -21,7 +21,7 @@ class SelectButton extends StatelessWidget {
             ? ElevatedButton(
                 child: Text(
                   this.text,
-                  style: Theme.of(context).textTheme.subtitle1,
+                  style: Theme.of(context).textTheme.titleSmall,
                   textAlign: TextAlign.center,
                 ),
                 onPressed: () => this.onPressed(),
@@ -29,7 +29,7 @@ class SelectButton extends StatelessWidget {
             : OutlinedButton(
                 child: Text(
                   this.text,
-                  style: Theme.of(context).textTheme.subtitle1,
+                  style: Theme.of(context).textTheme.titleSmall,
                   textAlign: TextAlign.center,
                 ),
                 onPressed: () => this.onPressed(),

--- a/fivekmrun_app_flutter/lib/login/loginPreview.dart
+++ b/fivekmrun_app_flutter/lib/login/loginPreview.dart
@@ -19,10 +19,10 @@ class LoginPreview extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Text("Влез като", style: textTheme.headline6),
+              Text("Влез като", style: textTheme.titleLarge),
               Padding(
                 padding: const EdgeInsets.only(top: 12),
-                child: Text(title, style: textTheme.headline6),
+                child: Text(title, style: textTheme.titleLarge),
               ),
               Hero(tag: "avatar", child: Avatar(url: avatrUrl ?? "")),
               Row(

--- a/fivekmrun_app_flutter/lib/login/login_with_id.dart
+++ b/fivekmrun_app_flutter/lib/login/login_with_id.dart
@@ -32,7 +32,7 @@ class _LoginWithIdState extends State<LoginWithId> {
 
   @override
   Widget build(BuildContext context) {
-    final textStlyle = Theme.of(context).textTheme.subtitle2;
+    final textStlyle = Theme.of(context).textTheme.titleSmall;
     final accentColor = Theme.of(context).colorScheme.secondary;
     return Column(
       mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/fivekmrun_app_flutter/lib/login/login_with_username.dart
+++ b/fivekmrun_app_flutter/lib/login/login_with_username.dart
@@ -56,7 +56,7 @@ class _LoginWithUsernameState extends State<LoginWithUsername> {
                 "Грешно потребителско име или парола",
                 textAlign: TextAlign.center,
                 style: TextStyle(
-                  color: Theme.of(context).errorColor,
+                  color: Theme.of(context).colorScheme.error,
                 ),
               ),
             ),

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -82,7 +82,6 @@ class MyApp extends StatelessWidget {
             bodyLarge: TextStyle(fontWeight: FontWeight.bold, fontSize: 10),
             bodyMedium: TextStyle(fontSize: 10),
           ),
-          errorColor: Colors.red,
           outlinedButtonTheme: OutlinedButtonThemeData(style: ButtonStyle(
               foregroundColor: MaterialStateProperty.resolveWith<Color?>(
                   (Set<MaterialState> states) {
@@ -99,12 +98,13 @@ class MyApp extends StatelessWidget {
               iconTheme: IconThemeData(color: Colors.white),
               titleTextStyle: Theme.of(context)
                   .textTheme
-                  .headline6
+                  .titleLarge
                   ?.copyWith(color: Colors.white)),
           colorScheme: ColorScheme.fromSwatch(
               primarySwatch: getColor(appAccentColor),
               backgroundColor: Colors.black,
               accentColor: appAccentColor,
+              errorColor: Colors.red,
               brightness: Brightness.dark),
         ),
         initialRoute: _initialRoute,

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -78,9 +78,9 @@ class MyApp extends StatelessWidget {
         theme: ThemeData(
           dividerColor: Colors.black12,
           textTheme: TextTheme(
-            subtitle1: TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
-            bodyText1: TextStyle(fontWeight: FontWeight.bold, fontSize: 10),
-            bodyText2: TextStyle(fontSize: 10),
+            titleSmall: TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+            bodyLarge: TextStyle(fontWeight: FontWeight.bold, fontSize: 10),
+            bodyMedium: TextStyle(fontSize: 10),
           ),
           errorColor: Colors.red,
           outlinedButtonTheme: OutlinedButtonThemeData(style: ButtonStyle(

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -76,31 +76,37 @@ class MyApp extends StatelessWidget {
         debugShowCheckedModeBanner: false,
         title: '5kmRun.bg',
         theme: ThemeData(
-            dividerColor: Colors.black12,
-            textTheme: TextTheme(
-              subtitle1: TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
-              bodyText1: TextStyle(fontWeight: FontWeight.bold, fontSize: 10),
-              bodyText2: TextStyle(fontSize: 10),
-            ),
-            errorColor: Colors.red,
-            outlinedButtonTheme: OutlinedButtonThemeData(style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color?>(
-                    (Set<MaterialState> states) {
-              return Colors.white;
-            }))),
-            textButtonTheme: TextButtonThemeData(style: ButtonStyle(
+          dividerColor: Colors.black12,
+          textTheme: TextTheme(
+            subtitle1: TextStyle(fontSize: 13, fontWeight: FontWeight.bold),
+            bodyText1: TextStyle(fontWeight: FontWeight.bold, fontSize: 10),
+            bodyText2: TextStyle(fontSize: 10),
+          ),
+          errorColor: Colors.red,
+          outlinedButtonTheme: OutlinedButtonThemeData(style: ButtonStyle(
               foregroundColor: MaterialStateProperty.resolveWith<Color?>(
                   (Set<MaterialState> states) {
-                return Colors.white;
-              }),
-            )),
-            appBarTheme: AppBarTheme(
-              backgroundColor: Color.fromRGBO(66, 66, 66, 1), 
+            return Colors.white;
+          }))),
+          textButtonTheme: TextButtonThemeData(style: ButtonStyle(
+            foregroundColor: MaterialStateProperty.resolveWith<Color?>(
+                (Set<MaterialState> states) {
+              return Colors.white;
+            }),
+          )),
+          appBarTheme: AppBarTheme(
+              backgroundColor: Color.fromRGBO(66, 66, 66, 1),
               iconTheme: IconThemeData(color: Colors.white),
-              
-              titleTextStyle: Theme.of(context).textTheme.headline6?.copyWith(color: Colors.white)), 
-            colorScheme: ColorScheme.fromSwatch(primarySwatch: getColor(appAccentColor)).copyWith(secondary: appAccentColor, brightness: Brightness.dark).copyWith(background: Colors.black)),
-            
+              titleTextStyle: Theme.of(context)
+                  .textTheme
+                  .headline6
+                  ?.copyWith(color: Colors.white)),
+          colorScheme: ColorScheme.fromSwatch(
+              primarySwatch: getColor(appAccentColor),
+              backgroundColor: Colors.black,
+              accentColor: appAccentColor,
+              brightness: Brightness.dark),
+        ),
         initialRoute: _initialRoute,
         routes: {
           '/': (_) => Login(),

--- a/fivekmrun_app_flutter/lib/offline_chart/add_offline_entry_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/add_offline_entry_page.dart
@@ -170,7 +170,7 @@ class _AddOfflineEntryPageState extends State<AddOfflineEntryPage> {
       if (result["errors"].contains("403")) {
         FirebaseCrashlytics.instance.recordError(
             Exception("Unexpected invalid 5kmRun token"), StackTrace.current);
-        final textStlyle = Theme.of(context).textTheme.subtitle2;
+        final textStlyle = Theme.of(context).textTheme.titleSmall;
         showDialog(
           context: context,
           useRootNavigator: true,
@@ -259,8 +259,7 @@ class _AddOfflineEntryPageState extends State<AddOfflineEntryPage> {
 
   void toggleActivity(StravaSummaryRun activity) {
     this.setState(() => this.selectedActivity =
-              this.selectedActivity == activity ? null : activity
-        );
+        this.selectedActivity == activity ? null : activity);
   }
 
   void triggerStravaAuth() {
@@ -295,7 +294,7 @@ class _AddOfflineEntryPageState extends State<AddOfflineEntryPage> {
           padding: const EdgeInsets.fromLTRB(8, 20, 8, 8),
           child: Text(
             "За да продължите - следвайте инструкциите и свържете 5kmRun приложението с вашия Strava профил.\n\nМоля, използвайте Google Chrome при свързването и въведете директно Strava потребителско име и парола. В момента, свързване с други браузъри не сработва успешно.\n\nСистемата на селфи отчита  „Elapsed time“, т.е. вашето общо (цялостно) време на бягането, което включва и времето при включена пауза или просто спрял на място! Много хора се заблуждават, че селфи ще им приеме тяхното „Moving Time“, което представлява само времето на движение без включените паузи и спиранията, т.е. случаите, при които се прекъсва бягането с използването на бутона „пауза“ или спиране на място!",
-            style: Theme.of(context).textTheme.subtitle2,
+            style: Theme.of(context).textTheme.titleSmall,
             textAlign: TextAlign.center,
           ),
         ),

--- a/fivekmrun_app_flutter/lib/offline_chart/details_tile.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/details_tile.dart
@@ -19,7 +19,7 @@ class DetailsTile extends StatelessWidget {
       children: <Widget>[
         Padding(
           padding: const EdgeInsets.only(top: 12),
-          child: Text(this.title, style: textTheme.bodyText2),
+          child: Text(this.title, style: textTheme.bodyMedium),
         ),
         Padding(
           padding: const EdgeInsets.only(top: 4, bottom: 8),

--- a/fivekmrun_app_flutter/lib/offline_chart/no_results_component.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/no_results_component.dart
@@ -8,7 +8,7 @@ class NoResultsComponent extends StatelessWidget {
       child: Column(
         children: [
           Text("Няма подходящи бягания!",
-              style: Theme.of(context).textTheme.subtitle1),
+              style: Theme.of(context).textTheme.titleSmall),
           Padding(
             padding: const EdgeInsets.only(
                 left: 36.0, top: 36.0, right: 36.0, bottom: 18.0),

--- a/fivekmrun_app_flutter/lib/offline_chart/offline_chart_details_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/offline_chart_details_page.dart
@@ -234,7 +234,7 @@ class IconText extends StatelessWidget {
           padding: const EdgeInsets.all(8),
           child: Text(
             text,
-            style: theme.textTheme.headline6,
+            style: theme.textTheme.titleLarge,
           ),
         ),
       ],

--- a/fivekmrun_app_flutter/lib/offline_chart/offline_chart_details_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/offline_chart_details_page.dart
@@ -102,9 +102,9 @@ class OfflineChartDetailsPage extends StatelessWidget {
                             DetailsTile(
                               title: "общо изкачване",
                               value: result.elevationGainedTotal
-                                          .round()
-                                          .toString() +
-                                      " m",
+                                      .round()
+                                      .toString() +
+                                  " m",
                               accentColor: iconColor,
                             ),
                           ],
@@ -198,7 +198,7 @@ class CircleWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textStyle =
-        Theme.of(context).textTheme.subtitle1?.copyWith(color: Colors.black);
+        Theme.of(context).textTheme.titleSmall?.copyWith(color: Colors.black);
     return Container(
       padding: EdgeInsets.all(24),
       child: Column(
@@ -256,13 +256,13 @@ class ComapreTime extends StatelessWidget {
         ? Color.fromRGBO(0, 173, 25, 1)
         : Color.fromRGBO(250, 32, 87, 1);
 
-    final numberStyle = textTheme.subtitle2?.copyWith(color: color);
+    final numberStyle = textTheme.titleSmall?.copyWith(color: color);
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         Text(
           text,
-          style: textTheme.subtitle2,
+          style: textTheme.titleSmall,
         ),
         Text(
           Run.timeInSecondsToString(time, sign: true),

--- a/fivekmrun_app_flutter/lib/offline_chart/offline_chart_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/offline_chart_page.dart
@@ -59,7 +59,7 @@ class _OfflineChartPageState extends State<OfflineChartPage> {
   void showLogoutDialog() {
     final authResource =
         Provider.of<AuthenticationResource>(context, listen: false);
-    final textStlyle = Theme.of(context).textTheme.subtitle2;
+    final textStlyle = Theme.of(context).textTheme.titleSmall;
     final accentColor = Theme.of(context).colorScheme.secondary;
     showDialog(
       context: context,
@@ -133,7 +133,7 @@ class _OfflineChartPageState extends State<OfflineChartPage> {
 
   @override
   Widget build(BuildContext context) {
-    final textStlyle = Theme.of(context).textTheme.headline6;
+    final textStlyle = Theme.of(context).textTheme.titleLarge;
     final accentColor = Theme.of(context).colorScheme.secondary;
 
     return Scaffold(

--- a/fivekmrun_app_flutter/lib/runs/run_details_page.dart
+++ b/fivekmrun_app_flutter/lib/runs/run_details_page.dart
@@ -26,8 +26,8 @@ class RunDetailsPage extends StatelessWidget {
               );
             case ConnectionState.done:
               if (snapshot.hasError)
-                return MilestoneGauge(
-                    run.position!, 400, Theme.of(context).colorScheme.secondary);
+                return MilestoneGauge(run.position!, 400,
+                    Theme.of(context).colorScheme.secondary);
               else
                 return MilestoneGauge(run.position!, snapshot.data?.length ?? 0,
                     Theme.of(context).colorScheme.secondary);
@@ -61,7 +61,7 @@ class RunDetailsPage extends StatelessWidget {
                           right: 0,
                           child: Text(
                             "Позиция",
-                            style: theme.textTheme.headline6,
+                            style: theme.textTheme.titleLarge,
                             textAlign: TextAlign.center,
                           ),
                         ),
@@ -80,7 +80,7 @@ class RunDetailsPage extends StatelessWidget {
                     SizedBox(height: 10),
                     Text(
                       "Темпо",
-                      style: theme.textTheme.subtitle2,
+                      style: theme.textTheme.titleSmall,
                     ),
                   ],
                 ),
@@ -90,7 +90,7 @@ class RunDetailsPage extends StatelessWidget {
                     SizedBox(height: 10),
                     Text(
                       "Време",
-                      style: theme.textTheme.subtitle2,
+                      style: theme.textTheme.titleSmall,
                     ),
                   ],
                 ),
@@ -100,7 +100,7 @@ class RunDetailsPage extends StatelessWidget {
                     SizedBox(height: 10),
                     Text(
                       "Скорост",
-                      style: theme.textTheme.subtitle2,
+                      style: theme.textTheme.titleSmall,
                     )
                   ],
                 ),
@@ -158,7 +158,7 @@ class CircleWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textStyle =
-        Theme.of(context).textTheme.subtitle1?.copyWith(color: Colors.black);
+        Theme.of(context).textTheme.titleSmall?.copyWith(color: Colors.black);
     return Container(
       padding: EdgeInsets.all(24),
       child: Column(
@@ -194,7 +194,7 @@ class IconText extends StatelessWidget {
           padding: const EdgeInsets.all(8),
           child: Text(
             text,
-            style: theme.textTheme.subtitle2,
+            style: theme.textTheme.titleSmall,
           ),
         ),
       ],
@@ -216,13 +216,13 @@ class CompareTime extends StatelessWidget {
         ? Color.fromRGBO(0, 173, 25, 1)
         : Color.fromRGBO(250, 32, 87, 1);
 
-    final numberStyle = textTheme.subtitle2?.copyWith(color: color);
+    final numberStyle = textTheme.titleSmall?.copyWith(color: color);
     return Row(
       mainAxisAlignment: MainAxisAlignment.center,
       children: <Widget>[
         Text(
           text,
-          style: textTheme.subtitle2,
+          style: textTheme.titleSmall,
         ),
         Text(
           Run.timeInSecondsToString(time, sign: true),
@@ -248,11 +248,11 @@ class RunDetail extends StatelessWidget {
       children: <Widget>[
         Text(
           label,
-          style: textTheme.subtitle2,
+          style: textTheme.titleSmall,
         ),
         Text(
           value,
-          style: textTheme.subtitle2,
+          style: textTheme.titleSmall,
         ),
       ],
     );


### PR DESCRIPTION
In this PR:
- Pass all needed theme colors  in [`colorScheme: ColorScheme.fromSwatch` constructor](https://github.com/etabakov/fivekmrun-app/blob/6160a8060d8e4d04e3be93d0249db635ce57717c/fivekmrun_app_flutter/lib/main.dart#L103-L108)
- Replace deprecated text style usages with the recommended ones