### PR TITLE
fix: prevent crash on invalid input in login with id

### DIFF
--- a/fivekmrun_app_flutter/lib/login/helpers.dart
+++ b/fivekmrun_app_flutter/lib/login/helpers.dart
@@ -1,5 +1,15 @@
 import 'package:flutter/material.dart';
 
+/// Parses a user ID from a string. Returns null if the input is not a valid
+/// positive integer.
+int? parseUserId(String input) {
+  final trimmed = input.trim();
+  if (trimmed.isEmpty) return null;
+  final value = int.tryParse(trimmed);
+  if (value == null || value <= 0) return null;
+  return value;
+}
+
 class InputHelpers {
   static InputDecoration decoration(String hint) {
     return InputDecoration(

--- a/fivekmrun_app_flutter/lib/login/login_with_id.dart
+++ b/fivekmrun_app_flutter/lib/login/login_with_id.dart
@@ -22,7 +22,13 @@ class _LoginWithIdState extends State<LoginWithId> {
   }
 
   void onPressed() async {
-    int userId = int.parse(numberInputController.text);
+    final userId = parseUserId(numberInputController.text);
+    if (userId == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Моля въведете валиден личен номер')),
+      );
+      return;
+    }
     await Provider.of<AuthenticationResource>(context, listen: false)
         .authenticateWithUserId(userId);
     Provider.of<UserResource>(context, listen: false).currentUserId = userId;

--- a/fivekmrun_app_flutter/test/common/login_with_id_test.dart
+++ b/fivekmrun_app_flutter/test/common/login_with_id_test.dart
@@ -1,0 +1,42 @@
+import 'package:fivekmrun_flutter/login/helpers.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseUserId', () {
+    test('parses a valid integer string', () {
+      expect(parseUserId('13731'), 13731);
+    });
+
+    test('parses a valid integer with surrounding whitespace', () {
+      expect(parseUserId('  42  '), 42);
+    });
+
+    test('returns null for empty string', () {
+      expect(parseUserId(''), null);
+    });
+
+    test('returns null for whitespace-only string', () {
+      expect(parseUserId('   '), null);
+    });
+
+    test('returns null for non-numeric input', () {
+      expect(parseUserId('abc'), null);
+    });
+
+    test('returns null for alphanumeric input', () {
+      expect(parseUserId('12abc'), null);
+    });
+
+    test('returns null for zero', () {
+      expect(parseUserId('0'), null);
+    });
+
+    test('returns null for negative number', () {
+      expect(parseUserId('-5'), null);
+    });
+
+    test('returns null for decimal input', () {
+      expect(parseUserId('3.14'), null);
+    });
+  });
+}


### PR DESCRIPTION
Replace int.parse() with a safe parseUserId() helper that uses int.tryParse() and rejects empty, non-numeric, zero, and negative values. The widget now shows a SnackBar instead of crashing when the user enters invalid input. Adds 9 unit tests covering all invalid input cases.