### PR TITLE
fix: set max brightness and keep screen on for barcode page

### DIFF
--- a/fivekmrun_app_flutter/lib/barcode_page.dart
+++ b/fivekmrun_app_flutter/lib/barcode_page.dart
@@ -6,12 +6,33 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
+import 'package:screen_brightness/screen_brightness.dart';
 import 'package:uuid/uuid.dart';
+import 'package:wakelock_plus/wakelock_plus.dart';
 
-class BarcodePage extends StatelessWidget {
+class BarcodePage extends StatefulWidget {
+  @override
+  _BarcodePageState createState() => _BarcodePageState();
+}
+
+class _BarcodePageState extends State<BarcodePage> {
   final Uuid uuid = Uuid();
   final issuerId = '3388000000022281825';
   final classId = 'MembershipCard';
+
+  @override
+  void initState() {
+    super.initState();
+    WakelockPlus.enable();
+    ScreenBrightness().setScreenBrightness(1.0);
+  }
+
+  @override
+  void dispose() {
+    WakelockPlus.disable();
+    ScreenBrightness().resetScreenBrightness();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/fivekmrun_app_flutter/pubspec.lock
+++ b/fivekmrun_app_flutter/pubspec.lock
@@ -904,6 +904,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  screen_brightness:
+    dependency: "direct main"
+    description:
+      name: screen_brightness
+      sha256: "7d4ac84ae26b37c01d6f5db7123a72db7933e1f2a2a8c369a51e08f81b3178d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  screen_brightness_android:
+    dependency: transitive
+    description:
+      name: screen_brightness_android
+      sha256: "8c69d3ac475e4d625e7fa682a3a51a69ff59abe5b4a9e57f6ec7d830a6c69bd6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  screen_brightness_ios:
+    dependency: transitive
+    description:
+      name: screen_brightness_ios
+      sha256: f08f70ca1ac3e30719764b5cfb8b3fe1e28163065018a41b3e6f243ab146c2f1
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  screen_brightness_macos:
+    dependency: transitive
+    description:
+      name: screen_brightness_macos
+      sha256: "70c2efa4534e22b927e82693488f127dd4a0f008469fccf4f0eefe9061bbdd6a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  screen_brightness_platform_interface:
+    dependency: transitive
+    description:
+      name: screen_brightness_platform_interface
+      sha256: "9f3ebf7f22d5487e7676fe9ddaf3fc55b6ff8057707cf6dc0121c7dfda346a16"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
+  screen_brightness_windows:
+    dependency: transitive
+    description:
+      name: screen_brightness_windows
+      sha256: c8e12a91cf6dd912a48bd41fcf749282a51afa17f536c3460d8d05702fb89ffa
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.1"
   scrollable_positioned_list:
     dependency: "direct main"
     description:

--- a/fivekmrun_app_flutter/pubspec.yaml
+++ b/fivekmrun_app_flutter/pubspec.yaml
@@ -64,6 +64,7 @@ dependencies:
   share_plus: ^12.0.0
   firebase_remote_config: ^5.0.0
   wakelock_plus: ^1.2.0
+  screen_brightness: ^1.0.1
   app_badge_plus: ^1.2.3
   mobile_scanner: ^7.1.3
 


### PR DESCRIPTION
Closes #139

## Changes

- Converted `BarcodePage` from `StatelessWidget` to `StatefulWidget` to access lifecycle hooks
- `initState`: enables `WakelockPlus` (screen stays on) and sets brightness to maximum via `screen_brightness` package
- `dispose`: restores both — wakelock disabled and brightness reset to the user's original level — so other screens are unaffected
- Added `screen_brightness: ^1.0.1` dependency

## Test plan

- [x] Open barcode screen → screen should jump to max brightness
- [x] Navigate away → brightness should return to normal system level
- [x] Open barcode screen → screen should not dim/sleep while displayed
- [x] Test on both iOS and Android

🤖 Generated with [Claude Code](https://claude.com/claude-code)