### PR TITLE
feat: tag builds with the publishing store as a Firebase user property

### DIFF
--- a/.github/workflows/upload-appstore.yml
+++ b/.github/workflows/upload-appstore.yml
@@ -77,7 +77,7 @@ jobs:
         run: cd fivekmrun_app_flutter && flutter pub get
 
       - name: Build Flutter
-        run: cd fivekmrun_app_flutter && flutter build ios --release --no-codesign
+        run: cd fivekmrun_app_flutter && flutter build ios --release --no-codesign --dart-define=STORE=app_store
       - name: Build resolve Swift dependencies
         run: xcodebuild -resolvePackageDependencies -workspace fivekmrun_app_flutter/ios/Runner.xcworkspace -scheme Runner -configuration Release
       - name: Build xArchive

--- a/.github/workflows/upload-huawei.yml
+++ b/.github/workflows/upload-huawei.yml
@@ -59,7 +59,7 @@ jobs:
         run: rm ./fivekmrun_app_flutter/android/app/google-services.json && echo "${{ secrets.FIREBASE_CONFIG }}" | base64 --decode > ./fivekmrun_app_flutter/android/app/google-services.json
 
       - name: Build APK
-        run: cd fivekmrun_app_flutter && flutter build apk --release --no-shrink
+        run: cd fivekmrun_app_flutter && flutter build apk --release --no-shrink --dart-define=STORE=huawei
 
       - name: Sign APK
         run: |

--- a/.github/workflows/upload-playstore.yml
+++ b/.github/workflows/upload-playstore.yml
@@ -45,7 +45,7 @@ jobs:
         run: rm ./fivekmrun_app_flutter/android/app/google-services.json && echo "${{ secrets.FIREBASE_CONFIG }}" | base64 --decode > ./fivekmrun_app_flutter/android/app/google-services.json
 
       - name: Build appbundle
-        run: cd fivekmrun_app_flutter && flutter build appbundle --release --no-shrink
+        run: cd fivekmrun_app_flutter && flutter build appbundle --release --no-shrink --dart-define=STORE=google_play
 
       - name: Sign App Bundle
         run: |

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:fivekmrun_flutter/barcode_page.dart';
@@ -31,6 +32,14 @@ void main() async {
   await Firebase.initializeApp();
 
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);
+
+  // Which store this build was published to. Compile-time, so no runtime cost and
+  // no HMS/GMS detection: each release workflow passes --dart-define=STORE=...
+  // Local and debug builds stay 'unknown' rather than polluting a real store's
+  // numbers. Note this only reaches Analytics on devices with Google Play
+  // services, so the huawei segment undercounts GMS-less Huawei devices.
+  const store = String.fromEnvironment('STORE', defaultValue: 'unknown');
+  await FirebaseAnalytics.instance.setUserProperty(name: 'store', value: store);
 
   // Pass all uncaught errors to Crashlytics.
   final originalOnError = FlutterError.onError;


### PR DESCRIPTION
Rebuilt on current master. **The previous version of this branch would have reverted the working Huawei pipeline** — it predated #201 and still carried the service-account auth, the `eatorb` action, and a build step without `--no-shrink`. Those are gone; this is now four small edits.

## What it does

Sets a `store` Firebase Analytics user property at startup so AppGallery installs are distinguishable from Play and App Store ones.

- `main.dart` — `String.fromEnvironment('STORE', defaultValue: 'unknown')`, compile-time, no runtime cost and no GMS/HMS detection
- Each release workflow passes `--dart-define=STORE=…`:

| Workflow | Value |
|---|---|
| `upload-appstore.yml` | `app_store` |
| `upload-playstore.yml` | `google_play` |
| `upload-huawei.yml` | `huawei` |

Local and debug builds stay `unknown` rather than inflating a real store's numbers. `firebase_analytics` was already a dependency.

## Why a user property, not a separate Firebase app

A **second Android app in the same project** was considered and rejected. Apps in one project are distinguished by package name, and both builds ship `bg.fivekmpark.fivekmrun` signed with the same keystore. A second entry would need a different `applicationId`, which means a **new AppGallery listing that existing Huawei users could never update to** — 3.14.4 is live there today. It also would not achieve separation: a Firebase project maps to one GA4 property, and each app is a data stream wi...

A **separate Firebase project** would genuinely separate the data, but FCM tokens are project-scoped, so push would need two-project routing on the backend, plus duplicated Remote Config and a split user base.

## Known limitation

Firebase Analytics requires Google Play services. On GMS-less Huawei devices it does not report at all, so the `huawei` segment **undercounts by an unknown margin** regardless of design. This is the GMS question #140 deferred; worth settling before reading much into the numbers. Documented at the property in `main.dart`.

## Verification

- `flutter analyze lib/main.dart` — no errors or warnings (12 pre-existing `prefer_const` infos, unchanged)
- `flutter test` — 196 passed
- `--no-shrink` preserved in both the Play and Huawei builds (load-bearing per #140: it was added in `081d97b` to stop a Jetifier OOM)

Not verifiable until a release: the property only appears in Firebase → User Properties after a build carrying it ships. Needs registering as a custom dimension in the console to show up in reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)