### PR TITLE
feat: target Android 16 (API 36) for Google Play compliance

### DIFF
--- a/fivekmrun_app_flutter/android/app/build.gradle
+++ b/fivekmrun_app_flutter/android/app/build.gradle
@@ -45,8 +45,8 @@ android {
         applicationId "bg.fivekmpark.fivekmrun"
         namespace "bg.fivekmpark.fivekmrun"
         minSdkVersion 26
-        targetSdkVersion 35
- 
+        targetSdkVersion 36
+
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/fivekmrun_app_flutter/lib/login/login.dart
+++ b/fivekmrun_app_flutter/lib/login/login.dart
@@ -21,37 +21,39 @@ class _LoginState extends State<Login> {
     final accentColor = Theme.of(context).colorScheme.secondary;
 
     return Scaffold(
-      body: Center(
-        child: Container(
-          width: 220,
-          height: 400,
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.end,
-            children: <Widget>[
-              this._buildLogo(),
-              SizedBox(height: 10),
-              Spacer(),
-              this.loginWithId ? LoginWithId() : LoginWithUsername(),
-              SizedBox(height: 4),
-              SizedBox(
-                width: double.infinity,
-                child: OutlinedButton(
-                  child:
-                      Text(this.loginWithId ? "влез с парола" : "влез с номер"),
-                  onPressed: this._toggleLogin,
+      body: SafeArea(
+        child: Center(
+          child: Container(
+            width: 220,
+            height: 400,
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.end,
+              children: <Widget>[
+                this._buildLogo(),
+                SizedBox(height: 10),
+                Spacer(),
+                this.loginWithId ? LoginWithId() : LoginWithUsername(),
+                SizedBox(height: 4),
+                SizedBox(
+                  width: double.infinity,
+                  child: OutlinedButton(
+                    child: Text(
+                        this.loginWithId ? "влез с парола" : "влез с номер"),
+                    onPressed: this._toggleLogin,
+                  ),
                 ),
-              ),
-              Spacer(),
-              Text("Нямате регистрация?"),
-              GestureDetector(
-                onTap: () => _loadRegistrationScreen(),
-                child: Text("Регистрирай се сега",
-                    style: TextStyle(
-                        color: accentColor,
-                        fontSize: 14,
-                        fontWeight: FontWeight.bold)),
-              )
-            ],
+                Spacer(),
+                Text("Нямате регистрация?"),
+                GestureDetector(
+                  onTap: () => _loadRegistrationScreen(),
+                  child: Text("Регистрирай се сега",
+                      style: TextStyle(
+                          color: accentColor,
+                          fontSize: 14,
+                          fontWeight: FontWeight.bold)),
+                )
+              ],
+            ),
           ),
         ),
       ),

--- a/fivekmrun_app_flutter/lib/login/loginPreview.dart
+++ b/fivekmrun_app_flutter/lib/login/loginPreview.dart
@@ -15,45 +15,47 @@ class LoginPreview extends StatelessWidget {
       final avatrUrl = user?.avatarUrl;
       final textTheme = Theme.of(context).textTheme;
       return Scaffold(
-        body: Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Text("Влез като", style: textTheme.titleLarge),
-              Padding(
-                padding: const EdgeInsets.only(top: 12),
-                child: Text(title, style: textTheme.titleLarge),
-              ),
-              Hero(tag: "avatar", child: Avatar(url: avatrUrl ?? "")),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: <Widget>[
-                  Padding(
-                    padding: const EdgeInsets.only(right: 12.0),
-                    child: Container(
-                      width: 60,
-                      child: ElevatedButton(
-                        child: Icon(
-                          Icons.edit,
+        body: SafeArea(
+          child: Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+                Text("Влез като", style: textTheme.titleLarge),
+                Padding(
+                  padding: const EdgeInsets.only(top: 12),
+                  child: Text(title, style: textTheme.titleLarge),
+                ),
+                Hero(tag: "avatar", child: Avatar(url: avatrUrl ?? "")),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: <Widget>[
+                    Padding(
+                      padding: const EdgeInsets.only(right: 12.0),
+                      child: Container(
+                        width: 60,
+                        child: ElevatedButton(
+                          child: Icon(
+                            Icons.edit,
+                          ),
+                          onPressed: () {
+                            Navigator.pop(context);
+                          },
                         ),
-                        onPressed: () {
-                          Navigator.pop(context);
-                        },
                       ),
                     ),
-                  ),
-                  Container(
-                    width: 150,
-                    child: ElevatedButton(
-                        child: Text("Напред"),
-                        onPressed: () {
-                          Navigator.pushNamedAndRemoveUntil(
-                              context, "home", (_) => false);
-                        }),
-                  ),
-                ],
-              )
-            ],
+                    Container(
+                      width: 150,
+                      child: ElevatedButton(
+                          child: Text("Напред"),
+                          onPressed: () {
+                            Navigator.pushNamedAndRemoveUntil(
+                                context, "home", (_) => false);
+                          }),
+                    ),
+                  ],
+                )
+              ],
+            ),
           ),
         ),
       );


### PR DESCRIPTION
Closes #163

## What

Bumps `targetSdkVersion` 35 → 36 so the app stays publishable on Google Play after the **31 Aug 2026** deadline.

`compileSdkVersion` was already 36, so the toolchain change is a one-liner — no AGP or Gradle wrapper bump needed (verified below).

## Edge-to-edge audit

Android 16 makes edge-to-edge **mandatory** at `targetSdk 36` and ignores the `windowOptOutEdgeToEdgeEnforcement` opt-out. I audited every `Scaffold` in `lib/`:

| Screen | Status |
|---|---|
| All pages with an `AppBar` (runs, events, settings, barcode, donate, offline chart, chronometer, scanner, details pages) | ✅ Flutter's `Scaffold` insets `AppBar` automatically |
| `Home` (`bottomNavigationBar`) | ✅ `Scaffold` insets the nav bar and shrinks `body`'s `MediaQuery` accordingly |
| `ProfileDashboard` | ✅ already wrapped in `ColorfulSafeArea` (blurred overlay is intentional, works edge-to-edge) |
| `Login` | ⚠️ **fixed** — `Scaffold` with no `AppBar`, body laid out under the system bars |
| `LoginPreview` | ⚠️ **fixed** — same |

Both fixed by wrapping the body in `SafeArea`. (Diffs look larger than they are — `dart format` reflowed the nested blocks.)

Other Android 16 behaviour changes checked, no action needed:

- **Predictive back** — no `PopScope`/`WillPopScope`/`onWillPop` anywhere in `lib/`, so nothing intercepts back.
- **Orientation/resize locks ignored on ≥600dp** — the manifest has no `android:screenOrientation`, and `configChanges` already covers `orientation|screenSize|screenLayout|density`.
- **Background work quotas** — no foreground services; manifest declares only `INTERNET`, `ACCESS_NETWORK_STATE`, `CAMERA`.
- **`windowOptOutEdgeToEdgeEnforcement`** — not present in `styles.xml`, nothing to remove.

## Verified locally

- `flutter test` → **46 passed**
- `flutter build appbundle --release` → **succeeded** on AGP 8.6.0 / Gradle 8.7 / Flutter 3.38.3, no upgrade required
- Merged manifest confirms `targetSdkVersion="36"` (`build/app/intermediates/packaged_manifests/release/.../AndroidManifest.xml`)

## How to test

**Prerequisite:** an Android 16 (API 36) emulator — `Tools → Device Manager → Create Device → API 36`, or `sdkmanager "system-images;android-36;google_apis;arm64-v8a"`. Behaviour changes only apply on an API 36 *device*, so testing on API 35 or lower proves nothing.

```
flutter run --release -d <api-36-emulator>
```

Enable **gesture navigation** (Settings → System → Navigation mode) — it's the layout that most often exposes edge-to-edge bugs.

1. **Login screen** — logo and the "Регистрирай се сега" link fully visible, not clipped by the status bar or the gesture pill. Repeat in landscape.
2. **Login preview screen** — avatar and both buttons fully visible and tappable; the "Напред" button must not sit under the gesture pill.
3. **Profile tab** — blurred bar renders at the top; scroll to the bottom and confirm the last tile clears the bottom nav bar.
4. **Bottom navigation** — all five tabs tappable; no icon overlapped by the gesture pill.
5. **Every tab with an AppBar** (runs, events, offline chart, donate) — title not under the status bar; scroll lists to the end and confirm nothing is hidden behind the nav bar.
6. **Barcode screen** — barcode fully visible and scannable, not clipped.
7. **Barcode scanner** — grant the camera permission on first launch and confirm the preview starts (Android 16 tightened camera/media permissions).
8. **Predictive back** — from a details page, drag slowly from the left edge; the back preview animation should appear and releasing should navigate back. Repeat on the home tabs.
9. **Rotation / resize** — rotate on a tablet or foldable profile. Android 16 ignores orientation locks on ≥600dp displays, so verify landscape layouts don't overflow.
10. **Strava OAuth** — run the connect flow end to end; it leaves the app via a browser tab and returns through `CallbackActivity`.

## Rollout

Ship to **internal testing** first, verify on a real Android 16 device, then promote to production well ahead of 31 Aug 2026.

## Follow-up (out of scope)

`android.enableJetifier=true` in `gradle.properties` is deprecated and is the cause of the Jetifier OOM issues worked around in 4837cb8 / 081d97b. Worth trying to drop it in a separate PR.
