### PR TITLE
feat: add pull-to-refresh, and stop failed fetches from wiping cached data

### DIFF
--- a/fivekmrun_app_flutter/lib/common/refresh_helper.dart
+++ b/fivekmrun_app_flutter/lib/common/refresh_helper.dart
@@ -1,0 +1,72 @@
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/state/events_resource.dart';
+import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+/// Reloads the profile, runs and events resources.
+///
+/// Backs the pull-to-refresh gesture on the profile, runs and events tabs, so a
+/// refresh triggered on any of them updates the data on all three. The offline
+/// chart keeps its own data and is not refreshed here.
+///
+/// Never completes with an error: `RefreshIndicator` attaches no error handler
+/// to the future it gets back, so a rejection here would surface as an
+/// unhandled exception. Failures are reported to Crashlytics instead, and each
+/// resource keeps the data it already had.
+Future<void> refreshAllData(BuildContext context) async {
+  final userId =
+      Provider.of<AuthenticationResource>(context, listen: false).getUserId();
+
+  final userRes = Provider.of<UserResource>(context, listen: false);
+  final runsRes = Provider.of<RunsResource>(context, listen: false);
+  final futureEventsRes =
+      Provider.of<AllFutureEventsResource>(context, listen: false);
+  final pastEventsRes = Provider.of<PastEventsResource>(context, listen: false);
+
+  // eagerError: false — one unreachable endpoint shouldn't abandon the others.
+  await Future.wait(
+    <Future<dynamic>>[
+      if (userId != null)
+        reportOnFailure(userRes.getById(userId, true), "user"),
+      if (userId != null) reportOnFailure(runsRes.getByUserId(userId), "runs"),
+      reportOnFailure(futureEventsRes.getAll(), "future events"),
+      reportOnFailure(pastEventsRes.getAll(), "past events"),
+    ],
+    eagerError: false,
+  );
+}
+
+/// Awaits [future], swallowing any failure after reporting it to Crashlytics.
+///
+/// Use for data loads whose failure shouldn't reach the user as an error: the
+/// resources keep their previous value, so there is nothing to recover from.
+Future<void> reportOnFailure(Future<dynamic> future, String label) async {
+  try {
+    await future;
+  } catch (error, stackTrace) {
+    await FirebaseCrashlytics.instance.recordError(
+      error,
+      stackTrace,
+      reason: "refresh failed: $label",
+      fatal: false,
+    );
+  }
+}
+
+/// Wraps a centered [child] in an always-scrollable viewport that fills the
+/// available space, so the pull-to-refresh gesture still works while a screen
+/// is loading or showing an empty-state message.
+Widget refreshableMessage(Widget child) {
+  return LayoutBuilder(
+    builder: (context, constraints) => SingleChildScrollView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      child: ConstrainedBox(
+        constraints: BoxConstraints(minHeight: constraints.maxHeight),
+        child: Center(child: child),
+      ),
+    ),
+  );
+}

--- a/fivekmrun_app_flutter/lib/events/events_page.dart
+++ b/fivekmrun_app_flutter/lib/events/events_page.dart
@@ -1,4 +1,5 @@
 import 'package:fivekmrun_flutter/common/constants.dart';
+import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/select_button.dart';
 import 'package:fivekmrun_flutter/events/future_events.dart';
 import 'package:fivekmrun_flutter/events/past_events.dart';
@@ -27,25 +28,31 @@ class _EventsPage extends State<EventsPage> {
 
   Widget _buildEvents() {
     if (!this.futureEventSelected) {
-      return Consumer<PastEventsResource>(
-        builder: (context, eventsResource, child) {
-          if (eventsResource.loading) {
-            return Center(child: CircularProgressIndicator());
-          } else {
-            return PastEventsList(events: eventsResource.value);
-          }
-        },
+      return RefreshIndicator(
+        onRefresh: () => refreshAllData(context),
+        child: Consumer<PastEventsResource>(
+          builder: (context, eventsResource, child) {
+            if (eventsResource.loading) {
+              return refreshableMessage(CircularProgressIndicator());
+            } else {
+              return PastEventsList(events: eventsResource.value);
+            }
+          },
+        ),
       );
     }
 
-    return Consumer<AllFutureEventsResource>(
-      builder: (context, eventsResource, child) {
-        if (eventsResource.loading) {
-          return Center(child: CircularProgressIndicator());
-        } else {
-          return FutureEventsList(events: eventsResource.value);
+    return RefreshIndicator(
+      onRefresh: () => refreshAllData(context),
+      child: Consumer<AllFutureEventsResource>(
+        builder: (context, eventsResource, child) {
+          if (eventsResource.loading) {
+            return refreshableMessage(CircularProgressIndicator());
+          } else {
+            return FutureEventsList(events: eventsResource.value);
+          }
         }
-      }
+      ),
     );
   }
 

--- a/fivekmrun_app_flutter/lib/events/future_events.dart
+++ b/fivekmrun_app_flutter/lib/events/future_events.dart
@@ -17,6 +17,7 @@ class FutureEventsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       itemCount: events.length,
       itemBuilder: (BuildContext context, int i) {
         final Event event = events[i];

--- a/fivekmrun_app_flutter/lib/events/past_events.dart
+++ b/fivekmrun_app_flutter/lib/events/past_events.dart
@@ -17,6 +17,7 @@ class PastEventsList extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       itemCount: events.length,
       itemBuilder: (BuildContext context, int i) {
         return Card(

--- a/fivekmrun_app_flutter/lib/home.dart
+++ b/fivekmrun_app_flutter/lib/home.dart
@@ -1,5 +1,6 @@
 import 'package:after_layout/after_layout.dart';
 import 'package:fivekmrun_flutter/app_rating_manager.dart';
+import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/custom_icons.dart';
 import 'package:fivekmrun_flutter/donate/donate_page.dart';
 import 'package:fivekmrun_flutter/offline_chart/add_offline_entry_page.dart';
@@ -94,9 +95,18 @@ class _HomeState extends State<Home> with AfterLayoutMixin<Home> {
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Provider.of<UserResource>(context, listen: false).currentUserId = userId;
     });
-    Provider.of<RunsResource>(context, listen: false).getByUserId(userId);
-    Provider.of<AllFutureEventsResource>(context, listen: false).getAll();
-    Provider.of<PastEventsResource>(context, listen: false).getAll();
+    // Fire-and-forget: the resources notify their listeners when they land.
+    // A failed fetch leaves the previous data in place, so there is nothing to
+    // do here beyond keeping the error from going unhandled.
+    reportOnFailure(
+        Provider.of<RunsResource>(context, listen: false).getByUserId(userId),
+        "runs");
+    reportOnFailure(
+        Provider.of<AllFutureEventsResource>(context, listen: false).getAll(),
+        "future events");
+    reportOnFailure(
+        Provider.of<PastEventsResource>(context, listen: false).getAll(),
+        "past events");
 
     this._tabHelper = TabNavigationHelper(this);
     this._widgetOptions = <Widget>[

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -6,6 +6,7 @@ import 'package:fivekmrun_flutter/charts/runs_by_route_chart.dart';
 import 'package:fivekmrun_flutter/common/avatar.dart';
 import 'package:fivekmrun_flutter/common/badges.dart';
 import 'package:fivekmrun_flutter/common/legioner_status_helper.dart';
+import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/run_card.dart';
 import 'package:fivekmrun_flutter/constants.dart';
 import 'package:fivekmrun_flutter/custom_icons.dart';
@@ -70,131 +71,135 @@ class ProfileDashboard extends StatelessWidget {
         color: Color.fromRGBO(66, 66, 66, 0.7),
         overflowRules: OverflowRules.all(true),
         filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: ListView(
-          children: <Widget>[
-            Row(
-              mainAxisAlignment: MainAxisAlignment.center,
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
+        child: RefreshIndicator(
+            onRefresh: () => refreshAllData(context),
+            child: ListView(
+              physics: const AlwaysScrollableScrollPhysics(),
               children: <Widget>[
-                Expanded(
-                  flex: 3,
-                  child: Column(
-                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                    children: <Widget>[
-                      IconButton(
-                        icon: Icon(CustomIcons.barcode),
-                        onPressed: goToBarcode,
-                      ),
-                      MilestoneTile(
-                          value: runsRes.value
-                                  ?.where((r) => r.isSelfie)
-                                  .length
-                                  .toInt() ??
-                              0,
-                          milestone: LegionerStatusHelper.getNextMilestone(
-                              runsRes.value
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: <Widget>[
+                    Expanded(
+                      flex: 3,
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                        children: <Widget>[
+                          IconButton(
+                            icon: Icon(CustomIcons.barcode),
+                            onPressed: goToBarcode,
+                          ),
+                          MilestoneTile(
+                              value: runsRes.value
                                       ?.where((r) => r.isSelfie)
                                       .length
                                       .toInt() ??
-                                  0),
-                          title: "Легионер\nselfie"),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  flex: 5,
-                  child: Column(
-                    children: <Widget>[
-                      Stack(
-                        children: <Widget>[
-                          Avatar(url: user?.avatarUrl ?? ""),
-                          Positioned(
-                            bottom: 0,
-                            right: 0,
-                            child: profileBadge(),
-                          )
+                                  0,
+                              milestone: LegionerStatusHelper.getNextMilestone(
+                                  runsRes.value
+                                          ?.where((r) => r.isSelfie)
+                                          .length
+                                          .toInt() ??
+                                      0),
+                              title: "Легионер\nselfie"),
                         ],
                       ),
-                      Text(
-                        user?.name ?? "",
-                        style: textTheme.titleMedium,
-                        textAlign: TextAlign.center,
+                    ),
+                    Expanded(
+                      flex: 5,
+                      child: Column(
+                        children: <Widget>[
+                          Stack(
+                            children: <Widget>[
+                              Avatar(url: user?.avatarUrl ?? ""),
+                              Positioned(
+                                bottom: 0,
+                                right: 0,
+                                child: profileBadge(),
+                              )
+                            ],
+                          ),
+                          Text(
+                            user?.name ?? "",
+                            style: textTheme.titleMedium,
+                            textAlign: TextAlign.center,
+                          ),
+                          Text(""),
+                        ],
                       ),
-                      Text(""),
-                    ],
-                  ),
-                ),
-                Expanded(
-                  flex: 3,
-                  child: Column(
-                    children: <Widget>[
-                      Row(children: <Widget>[
-                        if (DateTime.now().month == 1 ||
-                            (DateTime.now().month == 12 &&
-                                DateTime.now().day >= 15))
-                          ShakeWidget(
-                              shakeConstant: ShakeSlowConstant1(),
-                              autoPlay: true,
-                              child: IconButton(
-                                icon: const Icon(Icons.redeem),
-                                color: Colors.red,
-                                onPressed: () => launchUrl(
-                                    Uri.parse(wrapUrl + user!.id.toString()),
-                                    mode: LaunchMode.externalApplication),
-                              )),
-                        IconButton(
-                          icon: const Icon(Icons.settings),
-                          onPressed: goToSettings,
-                        ),
-                      ]),
-                      MilestoneTile(
-                          value: runsRes.value
-                                  ?.where((r) => !r.isSelfie)
-                                  .length
-                                  .toInt() ??
-                              0,
-                          milestone: LegionerStatusHelper.getNextMilestone(
-                              runsRes.value
+                    ),
+                    Expanded(
+                      flex: 3,
+                      child: Column(
+                        children: <Widget>[
+                          Row(children: <Widget>[
+                            if (DateTime.now().month == 1 ||
+                                (DateTime.now().month == 12 &&
+                                    DateTime.now().day >= 15))
+                              ShakeWidget(
+                                  shakeConstant: ShakeSlowConstant1(),
+                                  autoPlay: true,
+                                  child: IconButton(
+                                    icon: const Icon(Icons.redeem),
+                                    color: Colors.red,
+                                    onPressed: () => launchUrl(
+                                        Uri.parse(
+                                            wrapUrl + user!.id.toString()),
+                                        mode: LaunchMode.externalApplication),
+                                  )),
+                            IconButton(
+                              icon: const Icon(Icons.settings),
+                              onPressed: goToSettings,
+                            ),
+                          ]),
+                          MilestoneTile(
+                              value: runsRes.value
                                       ?.where((r) => !r.isSelfie)
                                       .length
                                       .toInt() ??
-                                  0),
-                          title: "Легионер\nсъщинско"),
-                    ],
-                  ),
-                ),
-              ],
-            ),
-            Row(
-              children: [Timekeeping()],
-            ),
-            if (runsRes.loading) Center(child: CircularProgressIndicator()),
-            if (hasOfficialRuns)
-              this.buildRunsCards(runsRes.bestOfficialRun!,
-                  runsRes.lastOfficialRun!, "същинско"),
-            if (hasSelfieRuns)
-              this.buildRunsCards(
-                  runsRes.bestSelfieRun!, runsRes.lastSelfieRun!, "selfie"),
-            if (hasAnyRuns) this.buildRunsChartCard(runs),
-            if (!runsRes.loading && !hasAnyRuns)
-              Row(
-                children: <Widget>[
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.only(top: 8.0),
-                      child: Center(
-                        child:
-                            Text("Все още не сте направили първото си бягане"),
+                                  0,
+                              milestone: LegionerStatusHelper.getNextMilestone(
+                                  runsRes.value
+                                          ?.where((r) => !r.isSelfie)
+                                          .length
+                                          .toInt() ??
+                                      0),
+                              title: "Легионер\nсъщинско"),
+                        ],
                       ),
                     ),
-                  )
-                ],
-              ),
-            if (hasOfficialRuns) this.buildRunsByRouteCard(runs),
-            if (hasOfficialRuns) this.buildBestTimesCard(runs),
-          ],
-        ));
+                  ],
+                ),
+                Row(
+                  children: [Timekeeping()],
+                ),
+                if (runsRes.loading) Center(child: CircularProgressIndicator()),
+                if (hasOfficialRuns)
+                  this.buildRunsCards(runsRes.bestOfficialRun!,
+                      runsRes.lastOfficialRun!, "същинско"),
+                if (hasSelfieRuns)
+                  this.buildRunsCards(
+                      runsRes.bestSelfieRun!, runsRes.lastSelfieRun!, "selfie"),
+                if (hasAnyRuns) this.buildRunsChartCard(runs),
+                if (!runsRes.loading && !hasAnyRuns)
+                  Row(
+                    children: <Widget>[
+                      Expanded(
+                        child: Padding(
+                          padding: const EdgeInsets.only(top: 8.0),
+                          child: Center(
+                            child: Text(
+                                "Все още не сте направили първото си бягане"),
+                          ),
+                        ),
+                      )
+                    ],
+                  ),
+                if (hasOfficialRuns) this.buildRunsByRouteCard(runs),
+                if (hasOfficialRuns) this.buildBestTimesCard(runs),
+              ],
+            )));
   }
 
   Widget buildRunsCards(Run bestRun, Run lastRun, String runType) {

--- a/fivekmrun_app_flutter/lib/runs/user_runs_page.dart
+++ b/fivekmrun_app_flutter/lib/runs/user_runs_page.dart
@@ -1,4 +1,5 @@
 import 'package:fivekmrun_flutter/common/list_tile_row.dart';
+import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:flutter/material.dart';
@@ -11,17 +12,20 @@ class UserRunsPage extends StatelessWidget {
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(title: Text("Твоите Бягания")),
-        body: Consumer<RunsResource>(builder: (context, runsResource, child) {
-          if (runsResource.loading) {
-            return Center(child: CircularProgressIndicator());
-          } else if (runsResource.value == null ||
-              runsResource.value?.length == 0) {
-            return Center(
-                child: Text("Все още не сте направили първото си бягане"));
-          } else {
-            return UserRunsList(runs: runsResource.value!);
-          }
-        }));
+        body: RefreshIndicator(
+          onRefresh: () => refreshAllData(context),
+          child: Consumer<RunsResource>(builder: (context, runsResource, child) {
+            if (runsResource.loading) {
+              return refreshableMessage(CircularProgressIndicator());
+            } else if (runsResource.value == null ||
+                runsResource.value?.length == 0) {
+              return refreshableMessage(
+                  Text("Все още не сте направили първото си бягане"));
+            } else {
+              return UserRunsList(runs: runsResource.value!);
+            }
+          }),
+        ));
   }
 }
 
@@ -41,6 +45,7 @@ class UserRunsList extends StatelessWidget {
     final darkerColor = Colors.white;
 
     return ListView.builder(
+      physics: const AlwaysScrollableScrollPhysics(),
       itemCount: runs.length,
       itemBuilder: (BuildContext context, int index) {
         final run = runs[index];

--- a/fivekmrun_app_flutter/lib/state/events_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/events_resource.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:fivekmrun_flutter/state/event_model.dart';
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:fivekmrun_flutter/constants.dart' as constants;
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
@@ -8,7 +9,9 @@ import 'package:http/http.dart' as http;
 abstract class EventsResource extends ChangeNotifier {
   String getEventUrl();
 
-  late List<Event> value;
+  // Not `late`: a failed fetch now leaves [value] untouched, so it has to be
+  // readable before the first successful load.
+  List<Event> value = <Event>[];
 
   bool _loading = true;
 
@@ -23,13 +26,13 @@ abstract class EventsResource extends ChangeNotifier {
   List<Event> listFromJsonParser(dynamic json);
 
   Future<List<Event>> getAll() async {
-    http.Response response = await http.get(Uri.parse("${this.getEventUrl()}"));
-    if (response.statusCode != 200 ||
-        response.headers["content-type"] != "application/json;charset=utf-8;") {
-      print('NO EVENTS RECEIVED');
-      //TODO: Fix this when endpoint behaves properly
-
-      return [];
+    final http.Response response;
+    try {
+      response = await http.get(Uri.parse("${this.getEventUrl()}"));
+      ensureJsonResponse(response, "events");
+    } catch (_) {
+      this.loading = false;
+      rethrow;
     }
 
     String body = utf8.decode(response.bodyBytes);
@@ -44,7 +47,7 @@ class FutureEventsResource extends EventsResource {
   String getEventUrl() {
     return constants.futureEventsUrl;
   }
-  
+
   @override
   List<Event> listFromJsonParser(json) {
     return Event.listFromJson(json);
@@ -56,7 +59,7 @@ class PastEventsResource extends EventsResource {
   String getEventUrl() {
     return constants.pastEventsUrl;
   }
-  
+
   @override
   List<Event> listFromJsonParser(json) {
     return Event.listFromJson(json);
@@ -88,7 +91,9 @@ class KidsFutureEventsResource extends EventsResource {
 }
 
 class AllFutureEventsResource extends ChangeNotifier {
-  late List<Event> value;
+  // Not `late`: a failed fetch now leaves [value] untouched, so it has to be
+  // readable before the first successful load.
+  List<Event> value = <Event>[];
 
   bool _loading = true;
 
@@ -101,14 +106,24 @@ class AllFutureEventsResource extends ChangeNotifier {
   }
 
   Future<List<Event>> getAll() async {
-    var futureEvents = await FutureEventsResource().getAll();
-    var xlFutureEvents = await XLFutureEventsResource().getAll();
-    var kidsFutureEvents = await KidsFutureEventsResource().getAll();
+    final List<Event> combined;
+    try {
+      var futureEvents = await FutureEventsResource().getAll();
+      var xlFutureEvents = await XLFutureEventsResource().getAll();
+      var kidsFutureEvents = await KidsFutureEventsResource().getAll();
+
+      combined = List<Event>.from(futureEvents)
+        ..addAll(xlFutureEvents)
+        ..addAll(kidsFutureEvents);
+    } catch (_) {
+      // Keep whatever was already loaded rather than blanking the events tab.
+      this.loading = false;
+      rethrow;
+    }
 
     this.loading = false;
-    this.value = List<Event>.from(futureEvents)..addAll(xlFutureEvents)..addAll(kidsFutureEvents);
-    this.value.sortBy((e) => e.date);
-    
+    this.value = combined..sortBy((e) => e.date);
+
     return this.value;
   }
 }

--- a/fivekmrun_app_flutter/lib/state/fetch_exception.dart
+++ b/fivekmrun_app_flutter/lib/state/fetch_exception.dart
@@ -1,0 +1,43 @@
+import 'package:http/http.dart' as http;
+
+/// Thrown when an endpoint answers with something we can't parse as run/event
+/// data — a non-200 status, or a body that isn't JSON.
+///
+/// This exists so callers can tell "the fetch failed" apart from "the fetch
+/// succeeded and there is nothing to show". Returning an empty list for both
+/// meant a transient server error silently wiped the user's history.
+class FetchException implements Exception {
+  /// What we were trying to load, e.g. "5km runs". Used in the message only.
+  final String resource;
+  final int statusCode;
+  final String? contentType;
+
+  const FetchException(this.resource, this.statusCode, this.contentType);
+
+  @override
+  String toString() => "FetchException: could not load $resource "
+      "(status $statusCode, content-type ${contentType ?? "none"})";
+}
+
+/// Whether a response carries JSON we can parse.
+///
+/// The content-type is matched on its prefix: the API returns
+/// `application/json;charset=utf-8;` today, but an exact-match check turns any
+/// change in casing, spacing or the trailing semicolon into a silent
+/// "no results" for every user.
+bool isJsonResponse(int statusCode, String? contentType) {
+  if (statusCode != 200 || contentType == null) {
+    return false;
+  }
+
+  return contentType.trimLeft().toLowerCase().startsWith("application/json");
+}
+
+/// Throws a [FetchException] unless [response] is a 200 carrying JSON.
+void ensureJsonResponse(http.Response response, String resource) {
+  final contentType = response.headers["content-type"];
+
+  if (!isJsonResponse(response.statusCode, contentType)) {
+    throw FetchException(resource, response.statusCode, contentType);
+  }
+}

--- a/fivekmrun_app_flutter/lib/state/runs_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/runs_resource.dart
@@ -1,3 +1,4 @@
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
@@ -46,12 +47,25 @@ class RunsResource extends ChangeNotifier {
     this._lastOfficialRun = null;
   }
 
+  /// Fetches the user's runs and replaces [value] on success.
+  ///
+  /// If the fetch fails the previously loaded runs are kept — an unreachable
+  /// server must not look the same as "this user has never run". The error is
+  /// rethrown so callers can react; see [refreshAllData].
   Future<List<Run>> getByUserId(int? userId) async {
-    List<Run> runs = (await this.retrieve5kmRuns(userId));
-    List<Run> selfieRuns = await this.retrieveSelfieRuns(userId);
-    runs.addAll(selfieRuns.where((r) => r.timeInSeconds != null));
+    if (userId == null) {
+      return this.value ?? <Run>[];
+    }
 
-    print("COUNT RUNS:" + runs.length.toString());
+    final List<Run> runs;
+    try {
+      runs = await this.retrieve5kmRuns(userId);
+      final List<Run> selfieRuns = await this.retrieveSelfieRuns(userId);
+      runs.addAll(selfieRuns.where((r) => r.timeInSeconds != null));
+    } catch (_) {
+      this.loading = false;
+      rethrow;
+    }
 
     this._processRuns(runs);
 
@@ -61,30 +75,18 @@ class RunsResource extends ChangeNotifier {
   }
 
   Future<List<Run>> retrieve5kmRuns(int? userId) async {
-    http.Response response =
+    final http.Response response =
         await http.get(Uri.parse("${constants.runsEndpointUrl}$userId"));
-    if (response.statusCode != 200 ||
-        response.headers["content-type"] != "application/json;charset=utf-8;") {
-      print('hello');
-      //TODO: Fix this when endpoint behaves properly
-
-      return [];
-    }
+    ensureJsonResponse(response, "5km runs");
 
     String body = utf8.decode(response.bodyBytes);
     return Run.listFromJson(jsonDecode(body));
   }
 
   Future<List<Run>> retrieveSelfieRuns(int? userId) async {
-    http.Response response =
+    final http.Response response =
         await http.get(Uri.parse("https://5kmrun.bg/api/selfie/user/$userId"));
-    if (response.statusCode != 200 ||
-        response.headers["content-type"] != "application/json;charset=utf-8;") {
-      print('hello');
-      //TODO: Fix this when endpoint behaves properly
-
-      return [];
-    }
+    ensureJsonResponse(response, "selfie runs");
 
     String body = utf8.decode(response.bodyBytes);
     return Run.selfieListFromJson(jsonDecode(body));

--- a/fivekmrun_app_flutter/test/common/fetch_exception_test.dart
+++ b/fivekmrun_app_flutter/test/common/fetch_exception_test.dart
@@ -1,0 +1,69 @@
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('isJsonResponse accepts', () {
+    test('the exact content-type the API sends today', () {
+      expect(isJsonResponse(200, "application/json;charset=utf-8;"), true);
+    });
+
+    // The previous exact-string check treated each of these as a failure and
+    // returned an empty list, which the app rendered as "no runs yet".
+    test('a content-type without the trailing semicolon', () {
+      expect(isJsonResponse(200, "application/json;charset=utf-8"), true);
+    });
+
+    test('a content-type with a space before the charset', () {
+      expect(isJsonResponse(200, "application/json; charset=utf-8"), true);
+    });
+
+    test('a content-type in different casing', () {
+      expect(isJsonResponse(200, "Application/JSON;charset=UTF-8"), true);
+    });
+
+    test('a bare application/json', () {
+      expect(isJsonResponse(200, "application/json"), true);
+    });
+
+    test('a content-type with leading whitespace', () {
+      expect(isJsonResponse(200, "  application/json"), true);
+    });
+  });
+
+  group('isJsonResponse rejects', () {
+    test('a 500 status', () {
+      expect(isJsonResponse(500, "application/json;charset=utf-8;"), false);
+    });
+
+    test('a 404 status', () {
+      expect(isJsonResponse(404, "application/json;charset=utf-8;"), false);
+    });
+
+    test('an HTML error page served with a 200', () {
+      expect(isJsonResponse(200, "text/html"), false);
+    });
+
+    test('a missing content-type', () {
+      expect(isJsonResponse(200, null), false);
+    });
+
+    test('a content-type that only mentions json later', () {
+      expect(
+          isJsonResponse(200, "text/html; fallback=application/json"), false);
+    });
+  });
+
+  test('FetchException message names the resource and the cause', () {
+    const exception = FetchException("5km runs", 503, "text/html");
+
+    expect(exception.toString(), contains("5km runs"));
+    expect(exception.toString(), contains("503"));
+    expect(exception.toString(), contains("text/html"));
+  });
+
+  test('FetchException message copes with a missing content-type', () {
+    const exception = FetchException("events", 500, null);
+
+    expect(exception.toString(), contains("none"));
+  });
+}


### PR DESCRIPTION
Closes #89. Also closes #165 and #166, which are defects in the fetch path that this feature makes reachable.

## The feature

`RefreshIndicator` on the **profile**, **runs** and **events** tabs. A refresh on any of them calls `refreshAllData`, which reloads the user, runs, future events and past events resources — so pulling on one tab updates all three.

Loading spinners and empty-state messages are wrapped in `refreshableMessage` (an always-scrollable viewport that fills the available height), and the lists get `AlwaysScrollableScrollPhysics`, so the gesture works even when there's nothing to scroll.

**Not included:** the offline chart tab. It has its own data source that `refreshAllData` doesn't touch, so wiring an indicator there would need `OfflineChartResource` added to the refresh set — left for #168 rather than half-done here.

## The two fixes

Both were pre-existing, but only reachable once per app launch. Pull-to-refresh lets a user hit them repeatedly on a flaky connection, so shipping the feature without them would have been a regression in practice.

### A failed fetch wiped the user's data (#166)

`retrieve5kmRuns` / `retrieveSelfieRuns` / `EventsResource.getAll` returned `[]` on failure, and the callers assigned that over the loaded value:

```dart
if (response.statusCode != 200 ||
    response.headers["content-type"] != "application/json;charset=utf-8;") {
  print('hello');
  return [];            // failure is indistinguishable from "no results"
}
...
this.value = runs;      // overwrites 353 runs with []
```

One transient 500 replaced a run history with *"Все още не сте направили първото си бягане"*. Worse, the content-type check was an exact string match — a change in casing, spacing or that trailing semicolon would have silently emptied the app for **every** user at once.

Now: failures throw `FetchException`, callers keep their previous `value`, and the content-type is matched on its prefix, case-insensitively, tolerating whitespace.

`EventsResource.value` and `AllFutureEventsResource.value` changed from `late List<Event>` to `List<Event> = []`. With failures no longer assigning, a throw before the first success would otherwise have left them uninitialised and thrown `LateInitializationError` in the widgets, which read `value` whenever `loading` is false.

### Refreshing offline threw an unhandled exception (#165)

`RefreshIndicator` calls `onRefresh()` and chains only `.whenComplete(...)` — no error handler. A rejected future became an unhandled async error plus a Crashlytics report, with nothing shown to the user.

`refreshAllData` now guards each load individually, reports failures to Crashlytics with the resource name, and always completes normally. `eagerError: false` means one unreachable endpoint doesn't abandon the other three. The same `reportOnFailure` guard wraps the fire-and-forget loads in `home.dart:initState`, which would otherwise have started throwing now that fetches surface errors.

Also fixes the unguarded null `userId` noted in #168 — `getByUserId` was called with a nullable id while `getById` was guarded, so a null id issued a request to `.../runs/null` and wiped the cache through the path above.

## Verified

- `flutter test` — **59 passed** (46 existing + 13 new)
- `flutter analyze lib/` — clean; the 12 remaining issues are all pre-existing and in untouched files
- `flutter build apk --debug` builds, installs and launches on an Android 16 emulator

New tests cover `isJsonResponse` — the exact header the API sends today, the four near-miss variants that the old exact-match check would have rejected, and the failure cases (non-200, HTML error page served as 200, missing header).

## Not verified

**The refresh path itself was not exercised at runtime.** Reaching it needs a logged-in account, and I didn't want to drive a live session against production data. Specifically untested on-device:

1. Pull to refresh on each of the three tabs with a working connection — data updates, spinner retracts
2. Pull to refresh in airplane mode — spinner retracts, **existing data stays on screen**, no red screen, a non-fatal Crashlytics event appears
3. Restore the connection and pull again — data reloads

Step 2 is the one that matters; it's the exact scenario both fixes target.

## Note on scope

`UserResource.getById` has the same wipe-on-failure shape — on a non-200 it assigns a placeholder `User(id: -1, name: " ")` over the real profile. Left alone to keep this diff reviewable; worth a follow-up issue.
