### PR TITLE
fix: allow pip install on macos-26 runner (PEP 668)

### DIFF
--- a/.github/workflows/upload-appstore.yml
+++ b/.github/workflows/upload-appstore.yml
@@ -93,7 +93,10 @@ jobs:
           APPSTORE_API_KEY_ID: ${{ secrets.APPSTORE_API_KEY_ID }}
           APPSTORE_API_PRIVATE_KEY: ${{ secrets.APPSTORE_API_PRIVATE_KEY }}
         run: |
-          pip3 install PyJWT cryptography --quiet
+          # --break-system-packages: the runner's Homebrew Python is marked
+          # externally managed (PEP 668), which makes a plain install abort.
+          # Safe here — the runner is discarded after the job.
+          pip3 install PyJWT cryptography --quiet --break-system-packages
           export VERSION=$(grep '^version:' fivekmrun_app_flutter/pubspec.yaml | sed 's/version: //' | cut -d'+' -f1)
           python3 - <<EOF
           import jwt, time, json, urllib.request, urllib.error, os, sys


### PR DESCRIPTION
## Problem

The `Create App Store draft version` step in `upload-appstore.yml` failed during the v3.18.0 release ([run 29952351766](https://github.com/5kmrun-bg/fivekmrun-app/actions/runs/29952351766)):

```
error: externally-managed-environment
× This environment is externally managed
╰─> To install Python packages system-wide, try brew install xyz...
```

The `macos-26` runner's Homebrew Python is marked externally managed (PEP 668), so a plain `pip3 install` refuses to install system-wide. Because the step runs under `shell: /bin/bash -e`, the failed install ended the step before the Python script could run — so the draft App Store version and its `whatsNew` localizations were never created.

This step was added after the last successful release, and the runner moved to `macos-26` in the same window, so it had never run green.

## Fix

Pass `--break-system-packages`. Safe on a throwaway CI runner, and the smallest change that unblocks the step.

A venv would be more robust against future runner changes, but touches more of the step; happy to switch if preferred.

## Note

The v3.18.0 iOS build **did** upload to TestFlight successfully — the earlier `Cannot determine the Apple ID from Bundle ID` failure was a pending App Store Connect agreement, since accepted. Only this last step failed, and the release notes for v3.18.0 are being set manually.

## Testing

Not exercised by `flutter test` — it's a CI workflow change, verified on the next App Store run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)