### PR TITLE
chore: add flutter_lints and analyzer configuration

### DIFF
--- a/fivekmrun_app_flutter/analysis_options.yaml
+++ b/fivekmrun_app_flutter/analysis_options.yaml
@@ -1,0 +1,20 @@
+# This file configures the analyzer, which statically analyzes Dart code to
+# check for errors, warnings, and lints.
+#
+# The lint rules applied to this project can be customized in the section below.
+# The included flutter_lints package activates a recommended set of lints for
+# Flutter apps. See https://dart.dev/lints and https://pub.dev/packages/flutter_lints.
+
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  errors:
+    # Keep the build green while the codebase is brought up to standard.
+    # These are surfaced in the IDE/`flutter analyze` but do not fail as errors.
+    avoid_print: warning
+    deprecated_member_use: info
+
+linter:
+  rules:
+    # The flutter_lints recommended set (included above) is the baseline.
+    # Add project-specific rules here as the codebase is cleaned up.

--- a/fivekmrun_app_flutter/pubspec.lock
+++ b/fivekmrun_app_flutter/pubspec.lock
@@ -526,6 +526,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_lints:
+    dependency: "direct dev"
+    description:
+      name: flutter_lints
+      sha256: a25a15ebbdfc33ab1cd26c63a6ee519df92338a9c10f122adda92938253bef04
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.3"
   flutter_rating_bar:
     dependency: transitive
     description:
@@ -736,6 +744,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  lints:
+    dependency: transitive
+    description:
+      name: lints
+      sha256: "0a217c6c989d21039f1498c3ed9f3ed71b354e69873f13a8dfc3c9fe76f1b452"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   logging:
     dependency: transitive
     description:

--- a/fivekmrun_app_flutter/pubspec.yaml
+++ b/fivekmrun_app_flutter/pubspec.yaml
@@ -78,6 +78,7 @@ dependency_overrides:
   cupertino_icons: ^1.0.3
 
 dev_dependencies:
+  flutter_lints: ^2.0.3
   build_runner: ^2.4.6
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## What

Adds static analysis tooling to the project:
- `flutter_lints: ^2.0.3` dev dependency (2.x for Dart 2.17+ compatibility per the `environment:` constraint)
- `analysis_options.yaml` including the `flutter_lints` recommended rule set

## Why

The project had no `analysis_options.yaml` and no lint package — the single biggest tooling gap in the repo. This wires up the standard Flutter lint set for local dev and IDE feedback.

## Notes

- **Nothing breaks:** CI only runs `flutter test` (not `flutter analyze`), so the surfaced issues are advisory. All 59 tests still pass.
- The baseline surfaces ~780 mostly-`info` issues (107 `prefer_const_constructors`, 27 `avoid_print`, etc.) to be worked down incrementally.
- `avoid_print` → `warning` and `deprecated_member_use` → `info` to keep the signal focused. A follow-up PR cleans up the `print()` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)