### PR TITLE
chore: remove debug print() statements from production code

### DIFF
--- a/fivekmrun_app_flutter/lib/charts/runs_chart.dart
+++ b/fivekmrun_app_flutter/lib/charts/runs_chart.dart
@@ -46,7 +46,6 @@ class _RunsChartState extends State<RunsChart> {
             "\nВреме: " +
             time +
             "");
-        print("model: time(" + date.toString() + "), value(" + time + ")");
       }
     }
 

--- a/fivekmrun_app_flutter/lib/common/badges.dart
+++ b/fivekmrun_app_flutter/lib/common/badges.dart
@@ -30,8 +30,6 @@ bool hasMaxBadge(List<Run>? runs) {
     return false;
   }
 
-  print("MAX BADGE");
-
   var yearsWon = <int>[];
   var officialRunsDates = runs
       .where((run) => run.date != null && !run.isSelfie)
@@ -45,15 +43,11 @@ bool hasMaxBadge(List<Run>? runs) {
     var actualRunsCount =
         officialRunsDates.where((date) => date.year == year).length;
 
-    print("$year expectedRunsCount: $expectedRunsCount");
-    print("$year actualRunsCount: $actualRunsCount");
-
     if (actualRunsCount >= expectedRunsCount) {
       yearsWon.add(year);
     }
   }
 
-  print(yearsWon);
   return yearsWon.length > 0;
 }
 
@@ -61,8 +55,6 @@ bool hasSelfieBadge(List<Run>? runs) {
   if (runs == null) {
     return false;
   }
-
-  print("SELFIE BADGE");
 
   var yearsWon = <int>[];
   var selfieRunDates = runs
@@ -77,14 +69,10 @@ bool hasSelfieBadge(List<Run>? runs) {
     var actualRunsCount =
         selfieRunDates.where((date) => date.year == year).length;
 
-    print("$year expectedRunsCount: $expectedRunsCount");
-    print("$year actualRunsCount: $actualRunsCount");
-
     if (actualRunsCount >= expectedRunsCount) {
       yearsWon.add(year);
     }
   }
 
-  print(yearsWon);
   return yearsWon.length > 0;
 }

--- a/fivekmrun_app_flutter/lib/home.dart
+++ b/fivekmrun_app_flutter/lib/home.dart
@@ -91,7 +91,6 @@ class _HomeState extends State<Home> with AfterLayoutMixin<Home> {
 
     final userId =
         Provider.of<AuthenticationResource>(context, listen: false).getUserId();
-    print("HOME: start loading userId $userId");
     WidgetsBinding.instance.addPostFrameCallback((_) {
       Provider.of<UserResource>(context, listen: false).currentUserId = userId;
     });

--- a/fivekmrun_app_flutter/lib/login/login.dart
+++ b/fivekmrun_app_flutter/lib/login/login.dart
@@ -72,7 +72,6 @@ class _LoginState extends State<Login> {
   }
 
   _loadRegistrationScreen() async {
-    print("load registration");
     FirebaseAnalytics.instance.logEvent(name: "open_registration_link");
     await launchUrl(Uri.parse("https://5kmrun.bg/register"));
   }

--- a/fivekmrun_app_flutter/lib/login/login_with_username.dart
+++ b/fivekmrun_app_flutter/lib/login/login_with_username.dart
@@ -40,7 +40,10 @@ class _LoginWithUsernameState extends State<LoginWithUsername> {
       } else {
         setState(() => this.loginError = true);
       }
-    }).catchError((error, stackTrace) => print("ERROR: " + error.toString()));
+    }).catchError((error, stackTrace) {
+      FirebaseCrashlytics.instance
+          .recordError(error, stackTrace, reason: "authenticate with username");
+    });
   }
 
   @override

--- a/fivekmrun_app_flutter/lib/offline_chart/add_offline_entry_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/add_offline_entry_page.dart
@@ -151,7 +151,6 @@ class _AddOfflineEntryPageState extends State<AddOfflineEntryPage> {
 
     var segments =
         stravaActivity?.segmentEfforts?.map((s) => s.segment?.id).toList();
-    print("segments: " + json.encode(segments));
     OfflineChartSubmissionModel model = new OfflineChartSubmissionModel(
       userId: userResource.currentUserId.toString(),
       elapsedTime: runSummary?.fastestSplit.elapsedTime.floor() ?? 0,

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -40,7 +40,6 @@ class ProfileDashboard extends StatelessWidget {
     final hasSelfieRuns =
         runs != null && runs.where((r) => r.isSelfie).length > 0;
 
-    print("HAS ANY RUNS: " + hasAnyRuns.toString());
     final goToSettings = () {
       Navigator.of(context, rootNavigator: true).pushNamed("settings");
     };

--- a/fivekmrun_app_flutter/lib/push_notifications_manager.dart
+++ b/fivekmrun_app_flutter/lib/push_notifications_manager.dart
@@ -1,4 +1,4 @@
-import 'dart:developer';
+import 'dart:developer' as developer;
 
 import 'package:app_badge_plus/app_badge_plus.dart';
 import 'package:firebase_core/firebase_core.dart';
@@ -44,9 +44,6 @@ class PushNotificationsManager {
         // (App in foreground)
         // on this event add new message in notification collection and hightlight the count on bell icon.
         // Add notificaion add in local storage and show in a list.
-        print("ON MESSAGE: ");
-        inspect(msg);
-
         showNotification(MyApp.navKey.currentState?.overlay?.context ?? context,
             title, body);
       });
@@ -135,5 +132,6 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
   // make sure you call `initializeApp` before using other Firebase services.
   await Firebase.initializeApp();
 
-  print("Handling a background message: ${message.messageId}");
+  developer.log("Handling a background message: ${message.messageId}",
+      name: "push_notifications");
 }

--- a/fivekmrun_app_flutter/lib/settings_page.dart
+++ b/fivekmrun_app_flutter/lib/settings_page.dart
@@ -51,7 +51,6 @@ class _SettingsPageState extends State<SettingsPage> {
                 Text("Известия"),
                 Switch(
                   onChanged: (value) {
-                    print("SET PUSH NOTIFICATION: " + value.toString());
                     final pushNotificationManager =
                         PushNotificationsManager.getInstance();
                     setState(() => localStorage.isSubscrubedForGeneral = value);

--- a/fivekmrun_app_flutter/lib/state/authentication_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/authentication_resource.dart
@@ -21,7 +21,6 @@ class AuthenticationResource extends ChangeNotifier {
 
     HttpClientResponse response = await request.close();
     String reply = await response.transform(utf8.decoder).join();
-    print(reply);
     httpClient.close();
     Map<String, dynamic> map = json.decode(reply);
     List<String> errors = List.from(map["errors"]);
@@ -113,8 +112,6 @@ class AuthenticationResource extends ChangeNotifier {
       final timestamp = prefs.getInt(constants.key_tokenTimestamp);
       if (timestamp != null) {
         final created = DateTime.fromMillisecondsSinceEpoch(timestamp);
-        print("AUTH.loadFromLocalStore token created: ${created.toString()}");
-
         final expiresAt =
             created.add(new Duration(days: constants.tokenExpiryDays));
         if (expiresAt.isAfter(DateTime.now())) {
@@ -122,8 +119,5 @@ class AuthenticationResource extends ChangeNotifier {
         }
       }
     }
-
-    print("AUTH.loadFromLocalStore userId: ${this._userId.toString()} ");
-    print("AUTH.loadFromLocalStore token: ${this._token}");
   }
 }

--- a/fivekmrun_app_flutter/lib/state/offline_chart_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/offline_chart_resource.dart
@@ -36,7 +36,6 @@ class OfflineChartResource extends ChangeNotifier {
 
     HttpClientResponse response = await request.close();
     String reply = await response.transform(utf8.decoder).join();
-    print(reply);
     httpClient.close();
     return json.decode(reply);
   }

--- a/fivekmrun_app_flutter/lib/state/offline_results_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/offline_results_resource.dart
@@ -37,8 +37,6 @@ class OfflineResultsResource extends ChangeNotifier {
 
     String weekFilter = "${lastWeek.year}/${_weekNumber(lastWeek)}";
 
-    print("WEEK FILTER: " + weekFilter);
-
     return _loadResultByWeek(weekFilter);
   }
 

--- a/fivekmrun_app_flutter/lib/state/results_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/results_resource.dart
@@ -25,7 +25,6 @@ class ResultsResource extends ChangeNotifier {
         .get(Uri.parse("${constants.resultEventsUrl}${eventId.toString()}"));
     if (response.statusCode != 200 ||
         response.headers["content-type"] != "application/json;charset=utf-8;") {
-      print('NO RESULTS RECEIVED');
       //TODO: Fix this when endpoint behaves properly
 
       return [];

--- a/fivekmrun_app_flutter/lib/state/user_model.dart
+++ b/fivekmrun_app_flutter/lib/state/user_model.dart
@@ -19,7 +19,6 @@ class User {
       name = user["u_name"] + " " + user["u_surname"];
       avatarUrl = user["pic"];
       donationsCount = user["u_sponsor"] ?? 0;
-      print("Has donated: " + donationsCount.toString());
       age = calculateAge(
           DateTime.fromMillisecondsSinceEpoch(user["u_bdate"] * 1000));
     } else {

--- a/fivekmrun_app_flutter/lib/timekeeping/timekeeping.dart
+++ b/fivekmrun_app_flutter/lib/timekeeping/timekeeping.dart
@@ -1,3 +1,5 @@
+import 'dart:developer' as developer;
+
 import 'package:flutter/material.dart';
 import 'package:firebase_remote_config/firebase_remote_config.dart';
 import 'package:provider/provider.dart';
@@ -15,12 +17,12 @@ class Timekeeping extends StatelessWidget {
 
       final String authorizedUsersJson =
           remoteConfig.getString('timekeeping_authorized_users');
-      print("config: " + authorizedUsersJson);
       final List<String> authorizedUsers = authorizedUsersJson.split(',');
 
       return authorizedUsers.contains(userId);
-    } catch (e) {
-      print('Error checking timekeeping authorization: $e');
+    } catch (e, stackTrace) {
+      developer.log('Error checking timekeeping authorization',
+          name: 'timekeeping', error: e, stackTrace: stackTrace);
       return false;
     }
   }


### PR DESCRIPTION
## What

Removes 24 leftover debug `print()` calls throughout `lib/`, and reroutes the few genuine logging sites through proper channels:

- **`login_with_username.dart`** — authentication failure now goes to `FirebaseCrashlytics.recordError` (with stack trace) instead of `print`
- **`timekeeping.dart`** — authorization error now uses `dart:developer` `log()` with the error + stack trace
- **`push_notifications_manager.dart`** — background-message handler uses `dart:developer` `log()`; the foreground `print` + `inspect(msg)` debug calls removed

## Why

- Debug `print()` calls ship to production and clutter device logs.
- Several removed calls in **`authentication_resource.dart`** were logging **sensitive data** — the raw auth API reply and the stored auth token — which should never be printed.

## Notes

- No behavioral change beyond logging. All 59 tests pass; `flutter analyze` reports no new warnings (`avoid_print` count drops to 0).
- Pairs with #171 (lint setup), which flags `avoid_print` going forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)