### PR TITLE
test: add state-layer model parsing tests

### DIFF
--- a/fivekmrun_app_flutter/test/state/event_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/event_model_test.dart
@@ -1,0 +1,78 @@
+import 'package:fivekmrun_flutter/state/event_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Event.fromJson', () {
+    test('parses a standard event', () {
+      final e = Event.fromJson({
+        "e_id": 1,
+        "e_title": "Race",
+        "e_date": 1609459200, // seconds
+        "e_time": "09:00",
+        "n_name": "Sofia",
+        "e_sponsor": "logo.png",
+      });
+      expect(e.id, 1);
+      expect(e.title, "Race");
+      expect(e.time, "09:00");
+      expect(e.location, "Sofia");
+      expect(e.imageUrl, "logo.png");
+      expect(e.detailsUrl, "");
+      expect(e.date, DateTime.fromMillisecondsSinceEpoch(1609459200 * 1000));
+    });
+  });
+
+  group('Event.fromXLJson', () {
+    test('uses n_name as the title and a fixed XL image/location', () {
+      final e = Event.fromXLJson({
+        "e_id": 2,
+        "n_name": "XL Route",
+        "e_date": 1609459200,
+        "e_time": "10:00",
+      });
+      expect(e.id, 2);
+      expect(e.title, "XL Route");
+      expect(e.location, "XLkm Run София");
+      expect(e.imageUrl, contains("xl-run-thumbnail"));
+    });
+  });
+
+  group('Event.fromKidsJson', () {
+    test('uses e_title as title and n_name as location', () {
+      final e = Event.fromKidsJson({
+        "e_id": 3,
+        "e_title": "Kids Race",
+        "n_name": "Playground",
+        "e_date": 1609459200,
+        "e_time": "11:00",
+      });
+      expect(e.id, 3);
+      expect(e.title, "Kids Race");
+      expect(e.location, "Playground");
+      expect(e.imageUrl, contains("kids-run"));
+    });
+  });
+
+  group('Event list parsers', () {
+    final raw = [
+      {
+        "e_id": 1,
+        "e_title": "Race",
+        "e_date": 1609459200,
+        "e_time": "09:00",
+        "n_name": "Sofia",
+        "e_sponsor": "logo.png",
+      }
+    ];
+
+    test('listFromJson maps every entry', () {
+      expect(Event.listFromJson(raw), hasLength(1));
+      expect(Event.listFromJson(raw).first.title, "Race");
+    });
+
+    test('listFromXLJson and listFromKidsJson map every entry', () {
+      expect(Event.listFromXLJson(raw), hasLength(1));
+      expect(Event.listFromKidsJson(raw), hasLength(1));
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/offline_chart_submission_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/offline_chart_submission_model_test.dart
@@ -1,0 +1,43 @@
+import 'package:fivekmrun_flutter/state/offline_chart_submission_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  OfflineChartSubmissionModel makeModel() => OfflineChartSubmissionModel(
+        userId: "42",
+        elapsedTime: 1500,
+        distance: 5000.0,
+        startDate: DateTime(2021, 6, 15, 8, 0, 0),
+        mapPath: "polyline",
+        startGeoLocation: [42.1, 23.2],
+        elevationLow: 1.0,
+        elevationHigh: 2.0,
+        elevationGainedTotal: 3.0,
+        startLocation: "Park",
+        totalDistance: 6000.0,
+        totalElapsedTime: 1800,
+        stravaLink: "http://strava/1",
+        segments: [10, 20, null],
+      );
+
+  group('OfflineChartSubmissionModel.toJson', () {
+    test('serializes the primitive fields', () {
+      final json = makeModel().toJson();
+      expect(json["userId"], "42");
+      expect(json["elapsedTime"], 1500);
+      expect(json["distance"], 5000.0);
+      expect(json["startDate"], DateTime(2021, 6, 15, 8, 0, 0).toString());
+      expect(json["mapPath"], "polyline");
+      expect(json["startGeoLocation"], [42.1, 23.2]);
+      expect(json["elevationLow"], 1.0);
+      expect(json["elevationHigh"], 2.0);
+      expect(json["elevationGainedTotal"], 3.0);
+      expect(json["startLocation"], "Park");
+      expect(json["stravaLink"], "http://strava/1");
+    });
+
+    test('stringifies the segments list', () {
+      final json = makeModel().toJson();
+      expect(json["segments"], "[10, 20, null]");
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/result_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/result_model_test.dart
@@ -1,0 +1,149 @@
+import 'package:fivekmrun_flutter/state/result_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  Map<String, dynamic> selfieJson() => {
+        "u_name": "Ivan",
+        "u_surname": "Petrov",
+        "s_uid": 42,
+        "s_time": 1500,
+        "s_total_elapsed_time": 1800,
+        "s_finish_pos": 3,
+        "u_runs_s": 60,
+        "u_sex": "M",
+        "s_type": 1,
+        "s_start_location": "Park",
+        "s_elevation_loss": 10,
+        "s_elevation_gained": 20,
+        "s_elevation_gained_total": 30,
+        "s_map": "polyline",
+        "s_distance": 5000,
+        "s_total_distance": 6000,
+        "s_start_date": "2021-06-15T08:00:00.000",
+        "s_strava_link": "http://strava/1",
+        "p_id": null,
+        "u_daritel": 0,
+      };
+
+  Map<String, dynamic> officialJson() => {
+        "u_name": "Ana",
+        "u_surname": "Ivanova",
+        "r_uid": 7,
+        "r_time": 1200,
+        "r_finish_pos": 1,
+        "r_runs": 40,
+        "u_help": 15,
+        "u_sex": "F",
+        "p_id": 99,
+      };
+
+  group('Result.fromJson (selfie)', () {
+    test('parses identity and formatted time fields', () {
+      final r = Result.fromJson(selfieJson());
+      expect(r.name, "Ivan Petrov");
+      expect(r.userId, 42);
+      expect(r.time, "25:00");
+      expect(r.totalTime, "30:00");
+      expect(r.position, 3);
+      expect(r.totalRuns, "60");
+      expect(r.sex, "M");
+      expect(r.pace, "05:00");
+    });
+
+    test('marks selfie, legioner status and elevation as doubles', () {
+      final r = Result.fromJson(selfieJson());
+      expect(r.isSelfie, isTrue);
+      expect(r.isLegioner, isTrue); // u_runs_s >= 50
+      expect(r.isDisqualified, isFalse); // s_type (1) <= 3
+      expect(r.elevationLow, 10.0);
+      expect(r.elevationHigh, 20.0);
+      expect(r.elevationGainedTotal, 30.0);
+      expect(r.stravaLink, "http://strava/1");
+    });
+
+    test('flags disqualification when s_type > 3', () {
+      final json = selfieJson()..["s_type"] = 4;
+      expect(Result.fromJson(json).isDisqualified, isTrue);
+    });
+
+    test('empty total time when elapsed is zero', () {
+      final json = selfieJson()..["s_total_elapsed_time"] = 0;
+      expect(Result.fromJson(json).totalTime, "");
+    });
+  });
+
+  group('Result.fromEventJson (official)', () {
+    test('parses fields and sums runs with helper count', () {
+      final r = Result.fromEventJson(officialJson());
+      expect(r.name, "Ana Ivanova");
+      expect(r.userId, 7);
+      expect(r.time, "20:00");
+      expect(r.position, 1);
+      expect(r.totalRuns, "55"); // 40 + 15
+      expect(r.isSelfie, isFalse);
+      expect(r.isPatreon, isTrue); // p_id != null
+      expect(r.isLegioner, isTrue); // 55 >= 50
+      expect(r.isAnonymous, isFalse);
+    });
+
+    test('treats r_uid == 0 as anonymous', () {
+      final json = officialJson()..["r_uid"] = 0;
+      expect(Result.fromEventJson(json).isAnonymous, isTrue);
+    });
+
+    test('defaults missing run counts to zero', () {
+      final json = officialJson()
+        ..remove("r_runs")
+        ..remove("u_help");
+      final r = Result.fromEventJson(json);
+      expect(r.totalRuns, "0");
+      expect(r.isLegioner, isFalse);
+    });
+  });
+
+  group('Result.checkPatreonship', () {
+    test('true when p_id present', () {
+      expect(Result.checkPatreonship({"p_id": 5}), isTrue);
+    });
+
+    test('true when u_daritel is a future timestamp', () {
+      final future =
+          DateTime.now().add(const Duration(days: 1)).millisecondsSinceEpoch;
+      expect(Result.checkPatreonship({"p_id": null, "u_daritel": future ~/ 1000}),
+          isTrue);
+    });
+
+    test('false when no patreon markers', () {
+      expect(Result.checkPatreonship({"p_id": null, "u_daritel": 0}), isFalse);
+    });
+  });
+
+  group('Result legioner helpers', () {
+    test('getLegionerType uses runs + help >= 50', () {
+      expect(Result.getLegionerType({"r_runs": 30, "u_help": 20}), isTrue);
+      expect(Result.getLegionerType({"r_runs": 30, "u_help": 19}), isFalse);
+      expect(Result.getLegionerType({}), isFalse);
+    });
+
+    test('getSelfieLegionerType uses u_runs_s >= 50', () {
+      expect(Result.getSelfieLegionerType({"u_runs_s": 50}), isTrue);
+      expect(Result.getSelfieLegionerType({"u_runs_s": 49}), isFalse);
+    });
+  });
+
+  group('Result list parsers', () {
+    test('listFromJson maps "runners"', () {
+      final list = Result.listFromJson({
+        "runners": [selfieJson(), selfieJson()]
+      });
+      expect(list, hasLength(2));
+      expect(list.first.isSelfie, isTrue);
+    });
+
+    test('listFromEventJson maps the given list', () {
+      final list = Result.listFromEventJson([officialJson()]);
+      expect(list, hasLength(1));
+      expect(list.first.name, "Ana Ivanova");
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/run_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/run_model_test.dart
@@ -1,0 +1,150 @@
+import 'package:fivekmrun_flutter/state/run_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Run.fromJson (official run)', () {
+    final json = {
+      "r_id": 123,
+      "r_eventid": 45,
+      "e_date": 1609459200, // 2021-01-01T00:00:00Z, in seconds
+      "r_time": 1500,
+      "n_name": "Sofia",
+      "r_finish_pos": 5,
+    };
+
+    test('parses core fields', () {
+      final run = Run.fromJson(json);
+      expect(run.id, 123);
+      expect(run.eventId, 45);
+      expect(run.timeInSeconds, 1500);
+      expect(run.location, "Sofia");
+      expect(run.position, 5);
+    });
+
+    test('derives formatted time, speed and pace', () {
+      final run = Run.fromJson(json);
+      expect(run.time, "25:00");
+      expect(run.totalTime, "25:00");
+      expect(run.speed, "12.00");
+      expect(run.pace, "05:00");
+    });
+
+    test('is not a selfie and defaults distance to 5000m', () {
+      final run = Run.fromJson(json);
+      expect(run.isSelfie, isFalse);
+      expect(run.distance, 5000);
+    });
+
+    test('converts the epoch-seconds date correctly', () {
+      final run = Run.fromJson(json);
+      expect(run.date,
+          DateTime.fromMillisecondsSinceEpoch(1609459200 * 1000));
+    });
+  });
+
+  group('Run.listFromJson', () {
+    test('maps the "runners" array', () {
+      final json = {
+        "runners": [
+          {"r_id": 1, "r_eventid": 1, "e_date": 1609459200, "r_time": 1500,
+            "n_name": "A", "r_finish_pos": 1},
+          {"r_id": 2, "r_eventid": 1, "e_date": 1609459200, "r_time": 1800,
+            "n_name": "B", "r_finish_pos": 2},
+        ]
+      };
+      final runs = Run.listFromJson(json);
+      expect(runs, hasLength(2));
+      expect(runs[0].id, 1);
+      expect(runs[1].timeInSeconds, 1800);
+    });
+  });
+
+  group('Run.fromSelfieJson', () {
+    final json = {
+      "s_id": 9,
+      "s_start_date": "2021-06-15T08:00:00.000",
+      "s_time": 1500,
+      "s_finish_pos": 2,
+      "s_total_distance": 6000,
+      "s_total_elapsed_time": 1800,
+    };
+
+    test('parses core fields and marks as selfie', () {
+      final run = Run.fromSelfieJson(json);
+      expect(run.id, 9);
+      expect(run.isSelfie, isTrue);
+      expect(run.eventId, isNull);
+      expect(run.position, 2);
+      expect(run.timeInSeconds, 1500);
+      expect(run.distance, 6000);
+      expect(run.time, "25:00");
+      expect(run.totalTime, "30:00");
+      expect(run.date, DateTime.parse("2021-06-15T08:00:00.000"));
+    });
+
+    test('falls back to defaults when distance/elapsed missing', () {
+      final run = Run.fromSelfieJson({
+        "s_id": 9,
+        "s_start_date": "2021-06-15T08:00:00.000",
+        "s_time": 1500,
+        "s_finish_pos": 2,
+      });
+      expect(run.distance, 5000);
+      expect(run.totalTime, "00:00");
+    });
+  });
+
+  group('Run.selfieListFromJson', () {
+    test('maps the "runs" array', () {
+      final json = {
+        "runs": [
+          {"s_id": 1, "s_start_date": "2021-06-15T08:00:00.000", "s_time": 1500,
+            "s_finish_pos": 1},
+        ]
+      };
+      final runs = Run.selfieListFromJson(json);
+      expect(runs, hasLength(1));
+      expect(runs.first.isSelfie, isTrue);
+    });
+  });
+
+  group('Run.timeInSecondsToString', () {
+    test('zero-pads minutes and seconds', () {
+      expect(Run.timeInSecondsToString(0), "00:00");
+      expect(Run.timeInSecondsToString(90), "01:30");
+      expect(Run.timeInSecondsToString(1500), "25:00");
+    });
+
+    test('prefixes a sign when requested', () {
+      expect(Run.timeInSecondsToString(90, sign: true), "+01:30");
+      expect(Run.timeInSecondsToString(-90, sign: true), "-01:30");
+    });
+  });
+
+  group('Run.timeInSecondsToSpeed', () {
+    test('returns empty string for zero', () {
+      expect(Run.timeInSecondsToSpeed(0), "");
+    });
+
+    test('computes km/h to two decimals', () {
+      expect(Run.timeInSecondsToSpeed(1500), "12.00");
+    });
+  });
+
+  group('Run.timeInSecondsToPace', () {
+    test('returns empty string for zero', () {
+      expect(Run.timeInSecondsToPace(0), "");
+    });
+
+    test('computes mm:ss pace per km', () {
+      expect(Run.timeInSecondsToPace(1500), "05:00");
+    });
+  });
+
+  group('Run.distanceToString', () {
+    test('formats metres as kilometres with two decimals', () {
+      expect(Run.distanceToString(5000), "5.00");
+      expect(Run.distanceToString(6250), "6.25");
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/run_simple_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/run_simple_model_test.dart
@@ -1,0 +1,55 @@
+import 'package:fivekmrun_flutter/state/run_simple_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('RunSimple.fromJson', () {
+    test('parses id, date and derived time/pace', () {
+      final r = RunSimple.fromJson({
+        "s_id": 5,
+        "s_cr_date": "2021-06-15T08:00:00.000",
+        "s_time": 1500,
+      });
+      expect(r.id, 5);
+      expect(r.date, DateTime.parse("2021-06-15T08:00:00.000"));
+      expect(r.timeInSeconds, 1500);
+      expect(r.time, "25:00");
+      expect(r.pace, "05:00");
+    });
+  });
+
+  group('RunSimple.listFromJson', () {
+    test('maps the "runs" array', () {
+      final list = RunSimple.listFromJson({
+        "runs": [
+          {"s_id": 1, "s_cr_date": "2021-06-15T08:00:00.000", "s_time": 1500},
+          {"s_id": 2, "s_cr_date": "2021-06-16T08:00:00.000", "s_time": 1800},
+        ]
+      });
+      expect(list, hasLength(2));
+      expect(list[1].time, "30:00");
+    });
+  });
+
+  group('RunSimple time helpers', () {
+    test('timeInSecondsToString zero-pads and supports sign', () {
+      expect(RunSimple.timeInSecondsToString(1500), "25:00");
+      expect(RunSimple.timeInSecondsToString(90, sign: true), "+01:30");
+    });
+
+    test('timeInSecondsToPace returns empty for zero', () {
+      expect(RunSimple.timeInSecondsToPace(0), "");
+      expect(RunSimple.timeInSecondsToPace(1500), "05:00");
+    });
+
+    test('displayDate uses dd.MM.yyyy', () {
+      final r = RunSimple(
+        id: 1,
+        date: DateTime(2021, 6, 15),
+        time: "25:00",
+        timeInSeconds: 1500,
+        pace: "05:00",
+      );
+      expect(r.displayDate, "15.06.2021");
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/user_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/user_model_test.dart
@@ -1,0 +1,67 @@
+import 'package:fivekmrun_flutter/state/user_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  User makeUser() => User(
+      id: 0, name: "", avatarUrl: "", age: 0, donationsCount: 0);
+
+  group('User.fromJson', () {
+    test('parses name, avatar and donations', () {
+      final json = {
+        "user": [
+          {
+            "u_name": "Ivan",
+            "u_surname": "Petrov",
+            "pic": "http://avatar/1.png",
+            "u_sponsor": 3,
+            "u_bdate": DateTime(1990, 1, 1).millisecondsSinceEpoch ~/ 1000,
+          }
+        ]
+      };
+      final user = User.fromJson(77, json);
+      expect(user.id, 77);
+      expect(user.name, "Ivan Petrov");
+      expect(user.avatarUrl, "http://avatar/1.png");
+      expect(user.donationsCount, 3);
+    });
+
+    test('defaults donations to zero when u_sponsor missing', () {
+      final json = {
+        "user": [
+          {
+            "u_name": "Ivan",
+            "u_surname": "Petrov",
+            "pic": "x",
+            "u_bdate": DateTime(1990, 1, 1).millisecondsSinceEpoch ~/ 1000,
+          }
+        ]
+      };
+      expect(User.fromJson(1, json).donationsCount, 0);
+    });
+
+    test('falls back to a fake user when the record is null', () {
+      final user = User.fromJson(5, {
+        "user": [null]
+      });
+      expect(user.id, 0);
+      expect(user.name, "fake user");
+    });
+  });
+
+  group('User.calculateAge', () {
+    test('counts full years for a birthday earlier in the year', () {
+      final now = DateTime.now();
+      final birth = DateTime(now.year - 30, 1, 1);
+      expect(makeUser().calculateAge(birth), 30);
+    });
+
+    test('does not count the current year before the birthday month', () {
+      final now = DateTime.now();
+      // A birth month strictly after the current month -> not yet had birthday.
+      if (now.month < 12) {
+        final birth = DateTime(now.year - 30, now.month + 1, 1);
+        expect(makeUser().calculateAge(birth), 29);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## What

Adds **46 unit tests** for the `lib/state/` models, which previously had zero coverage. The full suite grows from **59 → 105** tests.

| Model | What's covered |
|-------|----------------|
| `Run` | official & selfie JSON, list parsers, `timeInSecondsToString`/`Speed`/`Pace`, `distanceToString`, default fallbacks |
| `Result` | selfie & official JSON, patreon/legioner/anonymous/disqualified flags, runs+helper summing, list parsers |
| `User` | name concatenation, donation default, fake-user fallback, `calculateAge` |
| `Event` | standard / XL / kids JSON variants and their list parsers |
| `RunSimple` | JSON parsing, time helpers, `displayDate` formatting |
| `OfflineChartSubmissionModel` | `toJson` serialization (including the stringified `segments`) |

## Why

The models do all the API-response parsing and are exactly what breaks silently when the backend payload shifts. These are pure functions — fast host-run widget-free tests, no mocking needed — matching the project's stated preference for fast tests in CI.

## Notes

- Test-only change; no production code touched. All 105 tests pass locally.
- The resource classes (`*_resource.dart`) call package-level `http.get` directly, which needs dependency injection to test cleanly — a good follow-up, called out separately rather than bundled here.
- Independent of #171 and #172; can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)