### PR TITLE
refactor: inject http.Client into state resources for testability

### DIFF
--- a/fivekmrun_app_flutter/lib/state/events_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/events_resource.dart
@@ -7,6 +7,11 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 abstract class EventsResource extends ChangeNotifier {
+  /// Injectable for tests; defaults to a real client in production.
+  final http.Client _client;
+
+  EventsResource({http.Client? client}) : _client = client ?? http.Client();
+
   String getEventUrl();
 
   // Not `late`: a failed fetch now leaves [value] untouched, so it has to be
@@ -28,7 +33,7 @@ abstract class EventsResource extends ChangeNotifier {
   Future<List<Event>> getAll() async {
     final http.Response response;
     try {
-      response = await http.get(Uri.parse("${this.getEventUrl()}"));
+      response = await _client.get(Uri.parse("${this.getEventUrl()}"));
       ensureJsonResponse(response, "events");
     } catch (_) {
       this.loading = false;
@@ -43,6 +48,8 @@ abstract class EventsResource extends ChangeNotifier {
 }
 
 class FutureEventsResource extends EventsResource {
+  FutureEventsResource({super.client});
+
   @override
   String getEventUrl() {
     return constants.futureEventsUrl;
@@ -55,6 +62,8 @@ class FutureEventsResource extends EventsResource {
 }
 
 class PastEventsResource extends EventsResource {
+  PastEventsResource({super.client});
+
   @override
   String getEventUrl() {
     return constants.pastEventsUrl;
@@ -67,6 +76,8 @@ class PastEventsResource extends EventsResource {
 }
 
 class XLFutureEventsResource extends EventsResource {
+  XLFutureEventsResource({super.client});
+
   @override
   String getEventUrl() {
     return constants.xlFutureEventsUrl;
@@ -79,6 +90,8 @@ class XLFutureEventsResource extends EventsResource {
 }
 
 class KidsFutureEventsResource extends EventsResource {
+  KidsFutureEventsResource({super.client});
+
   @override
   String getEventUrl() {
     return constants.kidsFutureEventsUrl;
@@ -91,6 +104,11 @@ class KidsFutureEventsResource extends EventsResource {
 }
 
 class AllFutureEventsResource extends ChangeNotifier {
+  /// Injectable for tests; forwarded to the composed per-type resources.
+  final http.Client? _client;
+
+  AllFutureEventsResource({http.Client? client}) : _client = client;
+
   // Not `late`: a failed fetch now leaves [value] untouched, so it has to be
   // readable before the first successful load.
   List<Event> value = <Event>[];
@@ -108,9 +126,10 @@ class AllFutureEventsResource extends ChangeNotifier {
   Future<List<Event>> getAll() async {
     final List<Event> combined;
     try {
-      var futureEvents = await FutureEventsResource().getAll();
-      var xlFutureEvents = await XLFutureEventsResource().getAll();
-      var kidsFutureEvents = await KidsFutureEventsResource().getAll();
+      var futureEvents = await FutureEventsResource(client: _client).getAll();
+      var xlFutureEvents = await XLFutureEventsResource(client: _client).getAll();
+      var kidsFutureEvents =
+          await KidsFutureEventsResource(client: _client).getAll();
 
       combined = List<Event>.from(futureEvents)
         ..addAll(xlFutureEvents)

--- a/fivekmrun_app_flutter/lib/state/offline_results_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/offline_results_resource.dart
@@ -1,3 +1,4 @@
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:fivekmrun_flutter/state/result_model.dart';
 import 'package:flutter/widgets.dart';
 import 'package:http/http.dart' as http;
@@ -7,6 +8,12 @@ import 'dart:convert';
 import 'package:intl/intl.dart';
 
 class OfflineResultsResource extends ChangeNotifier {
+  /// Injectable for tests; defaults to a real client in production.
+  final http.Client _client;
+
+  OfflineResultsResource({http.Client? client})
+      : _client = client ?? http.Client();
+
   bool _loading = false;
 
   bool get loading => _loading;
@@ -48,10 +55,10 @@ class OfflineResultsResource extends ChangeNotifier {
   }
 
   Future<List<Result>?> _loadResultByWeek(String weekFilter) async {
-    http.Response response = await http
+    http.Response response = await _client
         .get(Uri.parse("${constants.offlineChartEndpointUrl}$weekFilter"));
-    if (response.statusCode != 200 ||
-        response.headers["content-type"] != "application/json;charset=utf-8;") {
+    if (!isJsonResponse(
+        response.statusCode, response.headers["content-type"])) {
       this.loading = false;
 
       return null;

--- a/fivekmrun_app_flutter/lib/state/results_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/results_resource.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:fivekmrun_flutter/state/result_model.dart';
 import 'package:fivekmrun_flutter/constants.dart' as constants;
 import 'package:flutter/material.dart';
@@ -6,6 +7,11 @@ import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
 class ResultsResource extends ChangeNotifier {
+  /// Injectable for tests; defaults to a real client in production.
+  final http.Client _client;
+
+  ResultsResource({http.Client? client}) : _client = client ?? http.Client();
+
   List<Result>? value;
 
   bool _loading = false;
@@ -21,13 +27,11 @@ class ResultsResource extends ChangeNotifier {
   Future<List<Result>> getAll(int eventId) async {
     this.loading = true;
 
-    http.Response response = await http
+    http.Response response = await _client
         .get(Uri.parse("${constants.resultEventsUrl}${eventId.toString()}"));
-    if (response.statusCode != 200 ||
-        response.headers["content-type"] != "application/json;charset=utf-8;") {
-      print('NO RESULTS RECEIVED');
-      //TODO: Fix this when endpoint behaves properly
-
+    if (!isJsonResponse(
+        response.statusCode, response.headers["content-type"])) {
+      this.loading = false;
       return [];
     }
 

--- a/fivekmrun_app_flutter/lib/state/runs_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/runs_resource.dart
@@ -6,6 +6,11 @@ import 'package:fivekmrun_flutter/constants.dart' as constants;
 import 'dart:convert';
 
 class RunsResource extends ChangeNotifier {
+  /// Injectable for tests; defaults to a real client in production.
+  final http.Client _client;
+
+  RunsResource({http.Client? client}) : _client = client ?? http.Client();
+
   Run? _bestOfficialRun;
   Run? _lastOfficialRun;
 
@@ -76,7 +81,7 @@ class RunsResource extends ChangeNotifier {
 
   Future<List<Run>> retrieve5kmRuns(int? userId) async {
     final http.Response response =
-        await http.get(Uri.parse("${constants.runsEndpointUrl}$userId"));
+        await _client.get(Uri.parse("${constants.runsEndpointUrl}$userId"));
     ensureJsonResponse(response, "5km runs");
 
     String body = utf8.decode(response.bodyBytes);
@@ -85,7 +90,7 @@ class RunsResource extends ChangeNotifier {
 
   Future<List<Run>> retrieveSelfieRuns(int? userId) async {
     final http.Response response =
-        await http.get(Uri.parse("https://5kmrun.bg/api/selfie/user/$userId"));
+        await _client.get(Uri.parse("https://5kmrun.bg/api/selfie/user/$userId"));
     ensureJsonResponse(response, "selfie runs");
 
     String body = utf8.decode(response.bodyBytes);

--- a/fivekmrun_app_flutter/lib/state/user_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/user_resource.dart
@@ -1,4 +1,5 @@
 import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:fivekmrun_flutter/state/run_simple_model.dart';
 import 'package:fivekmrun_flutter/state/user_model.dart';
 import 'package:flutter/widgets.dart';
@@ -9,6 +10,11 @@ import 'dart:convert';
 import 'package:intl/intl.dart';
 
 class UserResource extends ChangeNotifier {
+  /// Injectable for tests; defaults to a real client in production.
+  final http.Client _client;
+
+  UserResource({http.Client? client}) : _client = client ?? http.Client();
+
   bool _loading = true;
 
   bool get loading => _loading;
@@ -59,7 +65,8 @@ class UserResource extends ChangeNotifier {
 
     http.Response? response;
     try {
-      response = await http.get(Uri.parse("${constants.userEndpointUrl}$userId"));
+      response =
+          await _client.get(Uri.parse("${constants.userEndpointUrl}$userId"));
     } catch (e) {
       // No internet or server unreachable — show barcode with cached user ID.
       this.loading = false;
@@ -67,10 +74,9 @@ class UserResource extends ChangeNotifier {
       return this.value;
     }
 
-    if (response.statusCode != 200 ||
-        response.headers["content-type"] != "application/json;charset=utf-8;") {
+    if (!isJsonResponse(
+        response.statusCode, response.headers["content-type"])) {
       this.loading = false;
-      //TODO: Fix this when endpoint behaves properly
       this.value =
           new User(age: 0, name: " ", donationsCount: 0, id: -1, avatarUrl: "");
       return this.value;

--- a/fivekmrun_app_flutter/test/state/events_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/events_resource_test.dart
@@ -1,0 +1,70 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/state/events_resource.dart';
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+// One object carrying every key the three parsers read, so the same payload
+// works regardless of which event endpoint is requested.
+List<Map<String, dynamic>> _events() => [
+      {
+        "e_id": 1,
+        "e_title": "Race",
+        "e_date": 1609459200,
+        "e_time": "09:00",
+        "n_name": "Sofia",
+        "e_sponsor": "logo.png",
+      }
+    ];
+
+void main() {
+  group('FutureEventsResource.getAll', () {
+    test('parses events and clears loading on success', () async {
+      final client = MockClient((_) async =>
+          http.Response(jsonEncode(_events()), 200, headers: _jsonHeaders));
+      final resource = FutureEventsResource(client: client);
+
+      final events = await resource.getAll();
+
+      expect(events, hasLength(1));
+      expect(events.first.title, "Race");
+      expect(resource.loading, isFalse);
+    });
+
+    test('keeps previous value and rethrows on a failed fetch', () async {
+      final client = MockClient(
+          (_) async => http.Response("nope", 500, headers: _jsonHeaders));
+      final resource = FutureEventsResource(client: client);
+
+      await expectLater(resource.getAll(), throwsA(isA<FetchException>()));
+      expect(resource.value, isEmpty); // untouched
+      expect(resource.loading, isFalse);
+    });
+  });
+
+  group('AllFutureEventsResource.getAll', () {
+    test('combines the three future-event sources', () async {
+      final client = MockClient((_) async =>
+          http.Response(jsonEncode(_events()), 200, headers: _jsonHeaders));
+      final resource = AllFutureEventsResource(client: client);
+
+      final events = await resource.getAll();
+
+      // One event from each of Future, XL and Kids sources.
+      expect(events, hasLength(3));
+      expect(resource.loading, isFalse);
+    });
+
+    test('rethrows if any composed source fails', () async {
+      final client = MockClient(
+          (_) async => http.Response("nope", 500, headers: _jsonHeaders));
+      final resource = AllFutureEventsResource(client: client);
+
+      await expectLater(resource.getAll(), throwsA(isA<FetchException>()));
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/offline_results_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/offline_results_resource_test.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/state/offline_results_resource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+Map<String, dynamic> _selfieResult({required int type}) => {
+      "u_name": "Ivan",
+      "u_surname": "Petrov",
+      "s_uid": 42,
+      "s_time": 1500,
+      "s_total_elapsed_time": 1800,
+      "s_finish_pos": 1,
+      "u_runs_s": 10,
+      "u_sex": "M",
+      "s_type": type,
+      "s_start_location": "Park",
+      "s_elevation_loss": 0,
+      "s_elevation_gained": 0,
+      "s_elevation_gained_total": 0,
+      "s_map": "poly",
+      "s_distance": 5000,
+      "s_total_distance": 5000,
+      "s_start_date": "2021-06-15T08:00:00.000",
+      "s_strava_link": "http://strava",
+      "p_id": null,
+      "u_daritel": 0,
+    };
+
+void main() {
+  group('OfflineResultsResource.getThisWeekResults', () {
+    test('parses results and assigns official positions', () async {
+      final body = {
+        "runners": [
+          _selfieResult(type: 1), // valid
+          _selfieResult(type: 4), // disqualified
+          _selfieResult(type: 1), // valid
+        ]
+      };
+      final client = MockClient(
+          (_) async => http.Response(jsonEncode(body), 200, headers: _jsonHeaders));
+      final resource = OfflineResultsResource(client: client);
+
+      final results = await resource.getThisWeekResults();
+
+      expect(results, hasLength(3));
+      // Non-disqualified entries are numbered first, 1..N.
+      final valid = results!.where((r) => !r.isDisqualified).toList();
+      expect(valid.map((r) => r.officialPosition), [1, 2]);
+      // Disqualified numbering restarts at 1.
+      final dsq = results.where((r) => r.isDisqualified).toList();
+      expect(dsq.single.officialPosition, 1);
+      expect(resource.loading, isFalse);
+    });
+
+    test('returns null on a bad response', () async {
+      final client = MockClient(
+          (_) async => http.Response("boom", 503, headers: _jsonHeaders));
+      final resource = OfflineResultsResource(client: client);
+
+      expect(await resource.getThisWeekResults(), isNull);
+      expect(resource.loading, isFalse);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/results_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/results_resource_test.dart
@@ -1,0 +1,69 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/state/results_resource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+List<Map<String, dynamic>> _officialResults() => [
+      {
+        "u_name": "Ana",
+        "u_surname": "Ivanova",
+        "r_uid": 7,
+        "r_time": 1200,
+        "r_finish_pos": 1,
+        "r_runs": 40,
+        "u_help": 15,
+        "u_sex": "F",
+        "p_id": null,
+      }
+    ];
+
+void main() {
+  group('ResultsResource.getAll', () {
+    test('parses results and clears loading on success', () async {
+      final client = MockClient((_) async =>
+          http.Response(jsonEncode(_officialResults()), 200,
+              headers: _jsonHeaders));
+      final resource = ResultsResource(client: client);
+
+      final results = await resource.getAll(99);
+
+      expect(results, hasLength(1));
+      expect(results.first.name, "Ana Ivanova");
+      expect(resource.value, hasLength(1));
+      expect(resource.loading, isFalse);
+    });
+
+    test('returns empty list on a non-200 response', () async {
+      final client =
+          MockClient((_) async => http.Response("nope", 500, headers: _jsonHeaders));
+      final resource = ResultsResource(client: client);
+
+      expect(await resource.getAll(99), isEmpty);
+      expect(resource.loading, isFalse);
+    });
+
+    test('tolerates content-type casing/spacing variations (the old TODO)',
+        () async {
+      final client = MockClient((_) async => http.Response(
+          jsonEncode(_officialResults()), 200,
+          headers: {"content-type": "Application/JSON; charset=UTF-8"}));
+      final resource = ResultsResource(client: client);
+
+      final results = await resource.getAll(99);
+      expect(results, hasLength(1));
+    });
+
+    test('returns empty list when the body is not JSON at all', () async {
+      final client = MockClient((_) async =>
+          http.Response("<html>error</html>", 200,
+              headers: {"content-type": "text/html"}));
+      final resource = ResultsResource(client: client);
+
+      expect(await resource.getAll(99), isEmpty);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/runs_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/runs_resource_test.dart
@@ -1,0 +1,80 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/state/fetch_exception.dart';
+import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+final _official = {
+  "runners": [
+    {
+      "r_id": 1,
+      "r_eventid": 1,
+      "e_date": 1609459200,
+      "r_time": 1500,
+      "n_name": "Sofia",
+      "r_finish_pos": 1,
+    }
+  ]
+};
+
+final _selfie = {
+  "runs": [
+    {
+      "s_id": 2,
+      "s_start_date": "2021-06-15T08:00:00.000",
+      "s_time": 1800,
+      "s_finish_pos": 1,
+    }
+  ]
+};
+
+/// Routes the two endpoints [getByUserId] hits to the right payload.
+MockClient _client({int selfieStatus = 200}) => MockClient((request) async {
+      if (request.url.path.contains("selfie")) {
+        return http.Response(jsonEncode(_selfie), selfieStatus,
+            headers: _jsonHeaders);
+      }
+      return http.Response(jsonEncode(_official), 200, headers: _jsonHeaders);
+    });
+
+void main() {
+  group('RunsResource.getByUserId', () {
+    test('merges official and selfie runs on success', () async {
+      final resource = RunsResource(client: _client());
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(2));
+      expect(resource.loading, isFalse);
+      expect(resource.lastOfficialRun, isNotNull);
+      expect(resource.lastSelfieRun, isNotNull);
+      expect(resource.bestOfficialRun!.timeInSeconds, 1500);
+    });
+
+    test('returns cached value without fetching when userId is null', () async {
+      var called = false;
+      final resource = RunsResource(client: MockClient((_) async {
+        called = true;
+        return http.Response("{}", 200, headers: _jsonHeaders);
+      }));
+
+      final runs = await resource.getByUserId(null);
+
+      expect(runs, isEmpty);
+      expect(called, isFalse);
+    });
+
+    test('rethrows FetchException and stops loading when a fetch fails',
+        () async {
+      final resource = RunsResource(client: _client(selfieStatus: 500));
+
+      await expectLater(
+          resource.getByUserId(42), throwsA(isA<FetchException>()));
+      expect(resource.loading, isFalse);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/user_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/user_resource_test.dart
@@ -1,0 +1,46 @@
+import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+void main() {
+  // NOTE: the success path calls FirebaseAnalytics and so needs an initialised
+  // Firebase; these tests cover the id-guard and offline/bad-response fallbacks,
+  // which are the paths that used to be untestable.
+  group('UserResource.getById', () {
+    test('returns null for user id 0 without hitting the network', () async {
+      var called = false;
+      final resource = UserResource(client: MockClient((_) async {
+        called = true;
+        return http.Response("{}", 200, headers: _jsonHeaders);
+      }));
+
+      expect(await resource.getById(0), isNull);
+      expect(called, isFalse);
+    });
+
+    test('falls back to a barcode-only user when the network throws', () async {
+      final resource = UserResource(client: MockClient(
+          (_) async => throw http.ClientException("offline")));
+
+      final user = await resource.getById(42);
+
+      expect(user, isNotNull);
+      expect(user!.id, 42); // keeps the requested id for the barcode
+      expect(resource.loading, isFalse);
+    });
+
+    test('falls back to an empty user on a non-JSON response', () async {
+      final resource = UserResource(client: MockClient((_) async =>
+          http.Response("<html/>", 200, headers: {"content-type": "text/html"})));
+
+      final user = await resource.getById(42);
+
+      expect(user, isNotNull);
+      expect(user!.id, -1); // sentinel for "server misbehaved"
+      expect(resource.loading, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## What

Makes the `lib/state/` resource classes testable by injecting an `http.Client` instead of calling the package-level `http.get` directly. Each resource now takes an optional `client` (defaulting to a real `http.Client()` in production), so tests can supply a `MockClient`.

Refactored: `UserResource`, `ResultsResource`, `OfflineResultsResource`, `RunsResource`, and the `EventsResource` hierarchy (base + 4 subclasses + `AllFutureEventsResource`, which forwards the client to the sources it composes).

## Also in scope (the TODOs this unlocked)

- `user_resource`, `results_resource`, `offline_results_resource` still used the **fragile exact-match content-type check** (`== "application/json;charset=utf-8;"`) — the `//TODO: Fix this when endpoint behaves properly` spots. Migrated them to the existing `isJsonResponse()` helper (prefix + case/space tolerant), which already has unit coverage in `fetch_exception_test`.
- `results_resource` now also resets `loading = false` on the bad-response path (it previously stayed stuck at `true`).

## Tests

Adds **16 resource tests** using `MockClient` from `package:http/testing.dart` (no mockito needed):
- `ResultsResource` — success, non-200, non-JSON body, content-type casing/spacing tolerance
- `RunsResource` — official+selfie merge, null-userId short-circuit, `FetchException` rethrow
- `OfflineResultsResource` — position assignment (valid vs disqualified), bad-response → null
- `EventsResource` / `AllFutureEventsResource` — success, keep-previous-on-failure, three-source combine, rethrow
- `UserResource` — id-0 guard, offline fallback, non-JSON fallback (success path skipped: it calls `FirebaseAnalytics`, which needs an initialised Firebase)

All 75 tests pass; no new analyzer warnings.

## Notes

- Production behavior is unchanged for callers — the client param is optional.
- The `dart:io HttpClient`-based resources (`authentication_resource`, `offline_chart_resource`) use a different API and are a separate follow-up.
- **Minor overlap with #172**: both touch the `print('NO RESULTS RECEIVED')` line in `results_resource` (I removed it while rewriting that block). Trivial to resolve whichever merges second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)