### PR TITLE
chore: reassess dependency_overrides — drop 5 redundant, document the 1 that matters

### DIFF
--- a/fivekmrun_app_flutter/pubspec.lock
+++ b/fivekmrun_app_flutter/pubspec.lock
@@ -913,7 +913,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/fivekmrun_app_flutter/pubspec.yaml
+++ b/fivekmrun_app_flutter/pubspec.yaml
@@ -69,13 +69,14 @@ dependencies:
   mobile_scanner: ^7.1.3
   audioplayers: ^6.6.0
 
+# Load-bearing override: add_to_google_wallet -> flutter_svg (>=2.0.10) pulls in
+# http ^1.0.0, but the app is still on the http 0.13.x API. This pins http to
+# 0.13.x so resolution succeeds. Remove only as part of an http 1.x migration.
+# (The previous url_launcher/shared_preferences/intl/cupertino_icons/
+# plugin_platform_interface overrides were dropped in 2026 — they only duplicated
+# the top-level constraints and changed nothing in resolution.)
 dependency_overrides:
-  plugin_platform_interface: ^2.0.0
   http: ^0.13.0
-  url_launcher: ^6.3.2
-  shared_preferences: ^2.0.6
-  intl: ^0.17.0
-  cupertino_icons: ^1.0.3
 
 dev_dependencies:
   build_runner: ^2.4.6


### PR DESCRIPTION
## What

Investigated why each `dependency_overrides` entry exists and whether it's still needed, then removed the ones that aren't.

**Result:** 5 of 6 overrides removed; only `http` kept (and now documented).

## How I checked

Traced each override to its origin commit:
- `http` + `plugin_platform_interface` — added **Aug 2021** (`2eba26e`) during a Flutter/Firebase major upgrade to resolve version-solver conflicts.
- `url_launcher`, `shared_preferences`, `intl`, `cupertino_icons` — added **Aug 2021** (`6831c08` "use stable version of the package") to *force newer* versions back when the top-level deps were still old (`url_launcher` was `^5.7.7`).

Since then the top-level constraints have all been modernised, so those five now just **duplicate** the top-level constraint. Verified empirically:

| Package | Baseline (with override) | With override removed |
|---------|--------------------------|-----------------------|
| plugin_platform_interface | 2.1.8 | 2.1.8 |
| url_launcher | 6.3.2 | 6.3.2 |
| shared_preferences | 2.5.3 | 2.5.3 |
| intl | 0.17.0 | 0.17.0 |
| cupertino_icons | 1.0.8 | 1.0.8 |

The full `pubspec.lock` diff after removing all five is a **single metadata label** (`direct overridden` → `transitive`) — zero version drift.

## Why `http` stays

Removing it breaks resolution:

```
add_to_google_wallet 0.0.5 → flutter_svg ^2.0.10+1 → http ^1.0.0
```

…but the app is still on the **http 0.13.x** API. The override pins http to 0.13.x so solving succeeds. It's now documented inline in `pubspec.yaml`, with a note that removal belongs to a future http 1.x migration.

## Verification

- `flutter pub get` resolves cleanly.
- All 59 tests pass.
- Behavior unchanged — no dependency versions moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)