### PR TITLE
XLrun: group future events by day/location and show all distance options

### DIFF
--- a/fivekmrun_app_flutter/lib/events/future_events.dart
+++ b/fivekmrun_app_flutter/lib/events/future_events.dart
@@ -21,6 +21,7 @@ class FutureEventsList extends StatelessWidget {
       itemCount: events.length,
       itemBuilder: (BuildContext context, int i) {
         final Event event = events[i];
+        final bool isXL = event is XLEvent;
         return Card(
           child: ListTile(
             title: Row(
@@ -29,6 +30,11 @@ class FutureEventsList extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
+                      if (isXL)
+                        const Padding(
+                          padding: EdgeInsets.only(bottom: 4),
+                          child: XLBadge(),
+                        ),
                       ListTileRow(text: event.location, icon: Icons.pin_drop),
                       ListTileRow(
                           text: dateFromat.format(event.date),
@@ -38,7 +44,9 @@ class FutureEventsList extends StatelessWidget {
                         icon: Icons.watch,
                       ),
                       if (event.title.isNotEmpty)
-                        ListTileRow(text: event.title, icon: Icons.info),
+                        ListTileRow(
+                            text: event.title,
+                            icon: isXL ? Icons.terrain : Icons.info),
                     ],
                   ),
                 ),
@@ -63,6 +71,31 @@ class FutureEventsList extends StatelessWidget {
           ),
         );
       },
+    );
+  }
+}
+
+/// Marks an XLrun event card so it's visually distinguishable from regular
+/// event days in the merged future-events list.
+class XLBadge extends StatelessWidget {
+  const XLBadge({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
+      decoration: BoxDecoration(
+        color: Colors.blue,
+        borderRadius: BorderRadius.circular(16.0),
+      ),
+      child: const Text(
+        "XL",
+        style: TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 12.0,
+        ),
+      ),
     );
   }
 }

--- a/fivekmrun_app_flutter/lib/state/event_model.dart
+++ b/fivekmrun_app_flutter/lib/state/event_model.dart
@@ -87,7 +87,11 @@ class XLEvent extends Event {
   static const String _thumbnailUrl =
       "https://firebasestorage.googleapis.com/v0/b/kmrunbg.appspot.com/o/xl-run-thumbnail-bw.png?alt=media&token=bdccfa3c-9a5a-4792-bb04-bafaaad6442a";
 
-  // n_name is "<place name> <distance> км", e.g. "с. Кътина 4.8 км".
+  // n_name is usually "<place name> <distance> км", e.g. "с. Кътина 4.8 км",
+  // but some events instead suffix a tier word ("Къса"/"Средна"/"XL") with no
+  // number at all, and single-distance/relay events carry no suffix. So
+  // rather than assume a numeric suffix, the location is derived as the
+  // longest common prefix shared by every row in the group.
   static final RegExp _distanceSuffix =
       RegExp(r'\s+[\d.,]+\s*км\.?\s*$', caseSensitive: false);
   static final RegExp _distanceValue =
@@ -95,14 +99,20 @@ class XLEvent extends Event {
 
   factory XLEvent.fromRows(List<dynamic> rows) {
     final first = rows.first;
-    final String rawName = first["n_name"] ?? "";
-    final String location = rawName.replaceAll(_distanceSuffix, "").trim();
+    final List<String> rawNames =
+        rows.map<String>((row) => (row["n_name"] ?? "") as String).toList();
 
-    final List<String> distances = rows.map<String>((row) {
-      final String name = row["n_name"] ?? "";
-      final match = _distanceValue.firstMatch(name);
-      return match != null ? "${match.group(1)} km" : name;
-    }).toList();
+    final String location = _locationFrom(rawNames);
+
+    final List<String> distances = rawNames
+        .map((name) {
+          final String remainder = _stripPrefix(name, location).trim();
+          if (remainder.isEmpty) return "";
+          final match = _distanceValue.firstMatch(remainder);
+          return match != null ? "${match.group(1)} km" : remainder;
+        })
+        .where((d) => d.isNotEmpty)
+        .toList();
 
     return XLEvent(
       id: first["e_id"],
@@ -114,5 +124,43 @@ class XLEvent extends Event {
       detailsUrl: " ",
       distances: distances,
     );
+  }
+
+  static String _locationFrom(List<String> names) {
+    if (names.isEmpty) return "";
+    if (names.length == 1) {
+      final stripped = names.first.replaceAll(_distanceSuffix, "").trim();
+      return stripped.isNotEmpty ? stripped : names.first.trim();
+    }
+
+    String prefix = names.first;
+    for (final name in names.skip(1)) {
+      prefix = _commonPrefix(prefix, name);
+    }
+    prefix = prefix.trim();
+
+    // A too-short common prefix means these rows likely don't actually
+    // share a location name; fall back to stripping a numeric suffix off
+    // the first row instead of grouping on a near-empty string.
+    if (prefix.length < 3) {
+      return names.first.replaceAll(_distanceSuffix, "").trim();
+    }
+    return prefix;
+  }
+
+  static String _commonPrefix(String a, String b) {
+    final int len = a.length < b.length ? a.length : b.length;
+    int i = 0;
+    while (i < len && a[i] == b[i]) {
+      i++;
+    }
+    return a.substring(0, i);
+  }
+
+  static String _stripPrefix(String name, String prefix) {
+    if (prefix.isNotEmpty && name.startsWith(prefix)) {
+      return name.substring(prefix.length);
+    }
+    return name;
   }
 }

--- a/fivekmrun_app_flutter/lib/state/event_model.dart
+++ b/fivekmrun_app_flutter/lib/state/event_model.dart
@@ -26,15 +26,6 @@ class Event {
         detailsUrl = "",
         imageUrl = json["e_sponsor"];
 
-  Event.fromXLJson(d):
-      id = d["e_id"],
-      title = d["n_name"],
-      date = DateTime.fromMillisecondsSinceEpoch(d["e_date"] * 1000),
-      time = d["e_time"],
-      imageUrl = "https://firebasestorage.googleapis.com/v0/b/kmrunbg.appspot.com/o/xl-run-thumbnail-bw.png?alt=media&token=bdccfa3c-9a5a-4792-bb04-bafaaad6442a",
-      location = "XLkm Run София",
-      detailsUrl = " ";
-
   Event.fromKidsJson(d):
       id = d["e_id"],
       title = d["e_title"],
@@ -52,11 +43,21 @@ class Event {
     return result;
   }
 
+  // The XLrun endpoint returns one row per distance tier for a given
+  // day/location (short/medium/XL), sharing e_num + e_date. Group those rows
+  // into a single XLEvent per day/location instead of one card per distance.
   static List<Event> listFromXLJson(dynamic json) {
-    List<dynamic> events = json;
-    List<Event> result = events.map((d) => Event.fromXLJson(d)).toList();
+    List<dynamic> rows = json;
+    final Map<String, List<dynamic>> groups = {};
 
-    return result;
+    for (final row in rows) {
+      // Fall back to e_id when e_num is missing so unrelated rows don't
+      // collapse into a single group.
+      final key = "${row["e_num"] ?? row["e_id"]}_${row["e_date"]}";
+      groups.putIfAbsent(key, () => []).add(row);
+    }
+
+    return groups.values.map((rows) => XLEvent.fromRows(rows)).toList();
   }
 
   static List<Event> listFromKidsJson(dynamic json) {
@@ -64,5 +65,54 @@ class Event {
     List<Event> result = events.map((d) => Event.fromKidsJson(d)).toList();
 
     return result;
+  }
+}
+
+/// A grouped XLrun event: one card per day/location, carrying every
+/// distance tier offered that day (e.g. "4.8 km · 9.6 km · 14.4 km").
+class XLEvent extends Event {
+  final List<String> distances;
+
+  XLEvent({
+    required super.id,
+    required super.title,
+    required super.date,
+    required super.time,
+    required super.imageUrl,
+    required super.location,
+    required super.detailsUrl,
+    required this.distances,
+  });
+
+  static const String _thumbnailUrl =
+      "https://firebasestorage.googleapis.com/v0/b/kmrunbg.appspot.com/o/xl-run-thumbnail-bw.png?alt=media&token=bdccfa3c-9a5a-4792-bb04-bafaaad6442a";
+
+  // n_name is "<place name> <distance> км", e.g. "с. Кътина 4.8 км".
+  static final RegExp _distanceSuffix =
+      RegExp(r'\s+[\d.,]+\s*км\.?\s*$', caseSensitive: false);
+  static final RegExp _distanceValue =
+      RegExp(r'([\d.,]+)\s*км', caseSensitive: false);
+
+  factory XLEvent.fromRows(List<dynamic> rows) {
+    final first = rows.first;
+    final String rawName = first["n_name"] ?? "";
+    final String location = rawName.replaceAll(_distanceSuffix, "").trim();
+
+    final List<String> distances = rows.map<String>((row) {
+      final String name = row["n_name"] ?? "";
+      final match = _distanceValue.firstMatch(name);
+      return match != null ? "${match.group(1)} km" : name;
+    }).toList();
+
+    return XLEvent(
+      id: first["e_id"],
+      title: distances.join(" · "),
+      date: DateTime.fromMillisecondsSinceEpoch(first["e_date"] * 1000),
+      time: first["e_time"],
+      imageUrl: _thumbnailUrl,
+      location: location.isNotEmpty ? location : "XLkm Run София",
+      detailsUrl: " ",
+      distances: distances,
+    );
   }
 }

--- a/fivekmrun_app_flutter/test/events/future_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/future_events_test.dart
@@ -1,0 +1,54 @@
+import 'package:fivekmrun_flutter/events/future_events.dart';
+import 'package:fivekmrun_flutter/state/event_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+void main() {
+  testWidgets('regular event has no XL badge', (tester) async {
+    final event = Event.fromJson({
+      "e_id": 1,
+      "e_title": "Race",
+      "e_date": 1609459200,
+      "e_time": "09:00",
+      "n_name": "Sofia",
+      "e_sponsor": "",
+    });
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: [event])),
+        )));
+
+    expect(find.byType(XLBadge), findsNothing);
+    expect(find.text("Sofia"), findsOneWidget);
+    expect(find.text("Race"), findsOneWidget);
+  });
+
+  testWidgets('grouped XL event shows the XL badge, location and distances',
+      (tester) async {
+    final events = Event.listFromXLJson([
+      {
+        "e_id": 394,
+        "n_name": "с. Кътина 4.8 км",
+        "e_num": 5,
+        "e_date": 1786827600,
+        "e_time": "9:00",
+      },
+      {
+        "e_id": 395,
+        "n_name": "с. Кътина 9.6 км",
+        "e_num": 5,
+        "e_date": 1786827600,
+        "e_time": "9:00",
+      },
+    ]);
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: events)),
+        )));
+
+    expect(find.byType(XLBadge), findsOneWidget);
+    expect(find.text("с. Кътина"), findsOneWidget);
+    expect(find.text("4.8 km · 9.6 km"), findsOneWidget);
+  });
+}

--- a/fivekmrun_app_flutter/test/state/event_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/event_model_test.dart
@@ -96,7 +96,68 @@ void main() {
 
       expect(events, hasLength(1));
       final e = events.single as XLEvent;
-      expect(e.distances, ["XL Route"]);
+      // No numeric distance suffix and nothing to diff against within the
+      // group, so there's no distance info to show — just the location.
+      expect(e.location, "XL Route");
+      expect(e.distances, isEmpty);
+      expect(e.title, "");
+    });
+
+    test('groups rows suffixed with a tier word instead of a number', () {
+      // Real-world data: some events suffix n_name with "Къса"/"Средна"/"XL"
+      // instead of a numeric distance, e.g. "Бонсови Поляни – Люлин планина
+      // Къса" / "... Средна" / "... XL".
+      final events = Event.listFromXLJson([
+        {
+          "e_id": 401,
+          "n_name": "Бонсови Поляни – Люлин планина Къса",
+          "e_num": 13,
+          "e_date": 1795298400,
+          "e_time": "11:00",
+        },
+        {
+          "e_id": 402,
+          "n_name": "Бонсови Поляни – Люлин планина Средна",
+          "e_num": 13,
+          "e_date": 1795298400,
+          "e_time": "11:00",
+        },
+        {
+          "e_id": 403,
+          "n_name": "Бонсови Поляни – Люлин планина XL",
+          "e_num": 13,
+          "e_date": 1795298400,
+          "e_time": "11:00",
+        },
+      ]);
+
+      expect(events, hasLength(1));
+      final e = events.single as XLEvent;
+      expect(e.location, "Бонсови Поляни – Люлин планина");
+      expect(e.distances, ["Къса", "Средна", "XL"]);
+      expect(e.title, "Къса · Средна · XL");
+    });
+
+    test('a single-row group with no distance suffix shows only the location',
+        () {
+      // Real-world data: a relay-style event carries no per-row distance in
+      // n_name at all — the breakdown lives in e_title instead, which this
+      // parser doesn't attempt to read.
+      final events = Event.listFromXLJson([
+        {
+          "e_id": 400,
+          "n_name": "Западен парк",
+          "e_num": 2,
+          "e_date": 1792875600,
+          "e_time": "10:00",
+        },
+      ]);
+
+      expect(events, hasLength(1));
+      final e = events.single as XLEvent;
+      expect(e.location, "Западен парк");
+      expect(e.distances, isEmpty);
+      expect(e.title, "");
     });
   });
 

--- a/fivekmrun_app_flutter/test/state/event_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/event_model_test.dart
@@ -22,18 +22,81 @@ void main() {
     });
   });
 
-  group('Event.fromXLJson', () {
-    test('uses n_name as the title and a fixed XL image/location', () {
-      final e = Event.fromXLJson({
-        "e_id": 2,
-        "n_name": "XL Route",
-        "e_date": 1609459200,
-        "e_time": "10:00",
-      });
-      expect(e.id, 2);
-      expect(e.title, "XL Route");
-      expect(e.location, "XLkm Run София");
+  group('Event.listFromXLJson', () {
+    test('groups rows sharing e_num + e_date into a single XLEvent', () {
+      final events = Event.listFromXLJson([
+        {
+          "e_id": 394,
+          "n_name": "с. Кътина 4.8 км",
+          "e_num": 5,
+          "e_date": 1786827600,
+          "e_time": "9:00",
+          "e_title": "Къса дистанция",
+        },
+        {
+          "e_id": 395,
+          "n_name": "с. Кътина 9.6 км",
+          "e_num": 5,
+          "e_date": 1786827600,
+          "e_time": "9:00",
+          "e_title": "Средна дистанция",
+        },
+        {
+          "e_id": 396,
+          "n_name": "с. Кътина 14.4 км",
+          "e_num": 5,
+          "e_date": 1786827600,
+          "e_time": "9:00",
+          "e_title": "XL дистанция",
+        },
+      ]);
+
+      expect(events, hasLength(1));
+      final e = events.single as XLEvent;
+      expect(e.location, "с. Кътина");
+      expect(e.distances, ["4.8 km", "9.6 km", "14.4 km"]);
+      expect(e.title, "4.8 km · 9.6 km · 14.4 km");
+      expect(e.time, "9:00");
       expect(e.imageUrl, contains("xl-run-thumbnail"));
+      expect(e.date, DateTime.fromMillisecondsSinceEpoch(1786827600 * 1000));
+    });
+
+    test('keeps separate locations/days as separate groups', () {
+      final events = Event.listFromXLJson([
+        {
+          "e_id": 1,
+          "n_name": "с. Кътина 4.8 км",
+          "e_num": 5,
+          "e_date": 1786827600,
+          "e_time": "9:00",
+        },
+        {
+          "e_id": 2,
+          "n_name": "гр. Своге 6 км",
+          "e_num": 6,
+          "e_date": 1789419600,
+          "e_time": "9:00",
+        },
+      ]);
+
+      expect(events, hasLength(2));
+      expect((events[0] as XLEvent).location, "с. Кътина");
+      expect((events[1] as XLEvent).location, "гр. Своге");
+    });
+
+    test('falls back to e_id as the grouping key when e_num is missing', () {
+      final events = Event.listFromXLJson([
+        {
+          "e_id": 1,
+          "n_name": "XL Route",
+          "e_date": 1609459200,
+          "e_time": "10:00",
+        },
+      ]);
+
+      expect(events, hasLength(1));
+      final e = events.single as XLEvent;
+      expect(e.distances, ["XL Route"]);
     });
   });
 


### PR DESCRIPTION
## Summary

The XLrun future-events endpoint (`GET /api/xlrun/events`) returns one row per distance tier (short/medium/XL) for a given day/location, sharing `e_num` + `e_date`. `Event.fromXLJson` mapped every row identically — same hardcoded `location = "XLkm Run София"` and no distance/tier info — so an XLrun day rendered as 2-3 near-duplicate cards, all labeled the same, with no real place name and no indication of which distance was which.

- `Event.listFromXLJson` now groups raw rows by `e_num` + `e_date` (falling back to `e_id` when `e_num` is missing, so unrelated rows don't merge) into a new `XLEvent` model — one card per day/location.
- The real place name is derived as the **longest common prefix shared by every row's `n_name` in the group**, replacing the hardcoded location string. (See "Bug found during live verification" below for why this isn't a simple regex strip.)
- `XLEvent.distances` holds every distance offered that day (e.g. `["4.8 km", "9.6 km", "14.4 km"]`, or `["Къса", "Средна", "XL"]` for events that use tier words instead of numbers); the card's title row shows them joined as `"4.8 km · 9.6 km · 14.4 km"`.
- `FutureEventsList` shows a blue "XL" badge on grouped XLrun cards so they're visually distinguishable from regular event days — same visual language as the existing `RunTypePill` "XL" chip in `user_runs_page.dart`.

Out of scope (per the issue, follow-up work): start/finish location + track, and a "register for this XLrun event" button (#180 — that issue explicitly depends on this one for the grouped card to exist).

## Bug found during live verification (and fixed in a follow-up commit)

Running the built app against the **real** `/api/xlrun/events` endpoint on an Android emulator surfaced two cases the initial numeric-only `"N.N км"` regex didn't handle, both present in production data today:

- Some events suffix `n_name` with a tier word instead of a number — e.g. `"Бонсови Поляни – Люлин планина Къса"` / `"... Средна"` / `"... XL"`. No digits to match, so every row fell back to showing its full raw name as the "distance", producing a card that repeated the location three times in the distance line.
- Single-row groups with no distance suffix at all (a relay-style event, `"Западен парк"`, whose distance breakdown actually lives in `e_title` as `"ABO Pharma XL Щафета 4 х 3 х 2.5"`, not in `n_name`) rendered the location as a bogus one-item distance list.

Fixed by deriving the location as the longest common prefix shared by every row's `n_name` within a group, then computing each row's distance by stripping that prefix instead of pattern-matching a number. Numeric remainders still format as `"N.N km"`; non-numeric remainders (tier words) are kept as-is; empty remainders are dropped, so single-distance/relay events show just the location with no distance chips instead of a garbled duplicate.

## Test plan

- `flutter analyze` on the changed files: clean (aside from 2 pre-existing `unnecessary_new` infos in `future_events.dart` unrelated to this change).
- `flutter test`: full suite passes (139 tests), including:
  - Tests in `test/state/event_model_test.dart` covering grouping by `e_num`+`e_date`, separate groups for separate days/locations, the `e_id` fallback when `e_num` is absent, tier-word suffixes (`"Къса"/"Средна"/"XL"`), and single-row groups with no distance suffix.
  - Widget tests in `test/events/future_events_test.dart` verifying a regular event has no XL badge, and a grouped XL event shows the badge, parsed location, and joined distance list.
- **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app end-to-end against the live production API. Confirmed on-device:
  - Grouped cards show the blue "XL" badge, correct parsed location, and correctly joined distance chips (e.g. "с. Кътина" → "4.8 km · 9.6 km · 14.4 km").
  - The tier-word case ("Бонсови Поляни – Люлин планина" → "Къса · Средна · XL") and the no-suffix relay case ("Западен парк", no distance row shown) both render cleanly after the fix — this is what surfaced the bug described above in the first place.
  - Regular (non-XL) events are unaffected — no badge, normal layout.
- **iOS Simulator:** not run this pass — the iOS Simulator tool on this machine needs a one-time `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer` that requires an interactive password prompt, which isn't available in this automated environment. Flagging so a maintainer can either run that fix once or verify on iOS manually; the Dart-level logic is platform-agnostic and covered by the unit tests either way.

Closes #176