### PR TITLE
XLrun: add registration button to future event cards

### DIFF
--- a/fivekmrun_app_flutter/lib/events/future_events.dart
+++ b/fivekmrun_app_flutter/lib/events/future_events.dart
@@ -1,8 +1,10 @@
 import 'package:fivekmrun_flutter/common/constants.dart';
 import 'package:fivekmrun_flutter/common/list_tile_row.dart';
 import 'package:fivekmrun_flutter/state/event_model.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 final DateFormat dateFromat = DateFormat(Constants.DATE_FORMAT);
 
@@ -47,6 +49,24 @@ class FutureEventsList extends StatelessWidget {
                         ListTileRow(
                             text: event.title,
                             icon: isXL ? Icons.terrain : Icons.info),
+                      if (event is XLEvent &&
+                          event.registrationLinks.isNotEmpty)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 8),
+                          child: Wrap(
+                            spacing: 8,
+                            runSpacing: 4,
+                            children: event.registrationLinks
+                                .map((link) => OutlinedButton(
+                                      onPressed: () =>
+                                          _openRegistrationLink(link.url),
+                                      child: Text(link.label.isNotEmpty
+                                          ? link.label
+                                          : "Регистрация"),
+                                    ))
+                                .toList(),
+                          ),
+                        ),
                     ],
                   ),
                 ),
@@ -72,6 +92,11 @@ class FutureEventsList extends StatelessWidget {
         );
       },
     );
+  }
+
+  Future<void> _openRegistrationLink(String url) async {
+    FirebaseAnalytics.instance.logEvent(name: "open_xlrun_registration_link");
+    await launchUrl(Uri.parse(url), mode: LaunchMode.inAppWebView);
   }
 }
 

--- a/fivekmrun_app_flutter/lib/events/future_events.dart
+++ b/fivekmrun_app_flutter/lib/events/future_events.dart
@@ -25,72 +25,128 @@ class FutureEventsList extends StatelessWidget {
         final Event event = events[i];
         final bool isXL = event is XLEvent;
         return Card(
-          child: ListTile(
-            title: Row(
-              children: <Widget>[
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: <Widget>[
-                      if (isXL)
-                        const Padding(
-                          padding: EdgeInsets.only(bottom: 4),
-                          child: XLBadge(),
-                        ),
-                      ListTileRow(text: event.location, icon: Icons.pin_drop),
-                      ListTileRow(
-                          text: dateFromat.format(event.date),
-                          icon: Icons.calendar_today),
-                      ListTileRow(
-                        text: event.time,
-                        icon: Icons.watch,
-                      ),
-                      if (event.title.isNotEmpty)
-                        ListTileRow(
-                            text: event.title,
-                            icon: isXL ? Icons.terrain : Icons.info),
-                      if (event is XLEvent &&
-                          event.registrationLinks.isNotEmpty)
-                        Padding(
-                          padding: const EdgeInsets.only(top: 8),
-                          child: Wrap(
-                            spacing: 8,
-                            runSpacing: 4,
-                            children: event.registrationLinks
-                                .map((link) => OutlinedButton(
-                                      onPressed: () =>
-                                          _openRegistrationLink(link.url),
-                                      child: Text(link.label.isNotEmpty
-                                          ? link.label
-                                          : "Регистрация"),
-                                    ))
-                                .toList(),
+          clipBehavior: Clip.antiAlias,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              ListTile(
+                title: Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          if (isXL)
+                            const Padding(
+                              padding: EdgeInsets.only(top: 4, bottom: 10),
+                              child: XLBadge(),
+                            ),
+                          ListTileRow(
+                              text: event.location, icon: Icons.pin_drop),
+                          ListTileRow(
+                              text: dateFromat.format(event.date),
+                              icon: Icons.calendar_today),
+                          ListTileRow(
+                            text: event.time,
+                            icon: Icons.watch,
                           ),
-                        ),
-                    ],
-                  ),
-                ),
-                if (event.imageUrl.isNotEmpty)
-                  Container(
-                    width: 120,
-                    decoration: new BoxDecoration(
-                        borderRadius: new BorderRadius.only(
-                      topLeft: const Radius.circular(10.0),
-                      topRight: const Radius.circular(10.0),
-                    )),
-                    child: ClipRRect(
-                      borderRadius: BorderRadius.circular(5.0),
-                      child: Image.network(
-                        event.imageUrl,
-                        fit: BoxFit.fitWidth,
+                          if (event.title.isNotEmpty)
+                            ListTileRow(
+                                text: event.title,
+                                icon: isXL ? Icons.terrain : Icons.info),
+                        ],
                       ),
                     ),
-                  ),
-              ],
-            ),
+                    if (event.imageUrl.isNotEmpty)
+                      SizedBox(
+                        width: 120,
+                        child: ClipRRect(
+                          borderRadius: BorderRadius.circular(5.0),
+                          child: Image.network(
+                            event.imageUrl,
+                            fit: BoxFit.fitWidth,
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+              if (event is XLEvent && event.registrationLinks.isNotEmpty)
+                XLRegistrationSection(links: event.registrationLinks),
+            ],
           ),
         );
       },
+    );
+  }
+}
+
+/// The XLrun registration strip shown at the bottom of a future-event card:
+/// a full-bleed section marked off with a top divider and a "Регистрация"
+/// header, with one button per distance tier. Each button opens that tier's
+/// registration page in an in-app webview.
+class XLRegistrationSection extends StatelessWidget {
+  const XLRegistrationSection({Key? key, required this.links})
+      : super(key: key);
+
+  final List<XLRegistrationLink> links;
+
+  @override
+  Widget build(BuildContext context) {
+    final Color accent = Theme.of(context).colorScheme.secondary;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.fromLTRB(16, 10, 16, 12),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.04),
+        border: Border(
+          top: BorderSide(color: accent.withOpacity(0.35)),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          Row(
+            children: <Widget>[
+              Icon(Icons.how_to_reg, size: 18, color: accent),
+              const SizedBox(width: 6),
+              Text(
+                "Регистрация",
+                style: TextStyle(
+                  color: accent,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 13,
+                  letterSpacing: 0.3,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          Row(
+            children: <Widget>[
+              for (int j = 0; j < links.length; j++) ...<Widget>[
+                if (j > 0) const SizedBox(width: 8),
+                Expanded(
+                  child: OutlinedButton(
+                    onPressed: () => _openRegistrationLink(links[j].url),
+                    style: OutlinedButton.styleFrom(
+                      side: BorderSide(color: accent),
+                      padding: const EdgeInsets.symmetric(horizontal: 4),
+                    ),
+                    child: Text(
+                      links[j].label.isNotEmpty
+                          ? links[j].label
+                          : "Регистрация",
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ],
+      ),
     );
   }
 

--- a/fivekmrun_app_flutter/lib/state/event_model.dart
+++ b/fivekmrun_app_flutter/lib/state/event_model.dart
@@ -72,6 +72,7 @@ class Event {
 /// distance tier offered that day (e.g. "4.8 km · 9.6 km · 14.4 km").
 class XLEvent extends Event {
   final List<String> distances;
+  final List<XLRegistrationLink> registrationLinks;
 
   XLEvent({
     required super.id,
@@ -82,6 +83,7 @@ class XLEvent extends Event {
     required super.location,
     required super.detailsUrl,
     required this.distances,
+    required this.registrationLinks,
   });
 
   static const String _thumbnailUrl =
@@ -97,6 +99,8 @@ class XLEvent extends Event {
   static final RegExp _distanceValue =
       RegExp(r'([\d.,]+)\s*км', caseSensitive: false);
 
+  static const String _registerUrlPrefix = "https://5kmrun.bg/xlrun/event/";
+
   factory XLEvent.fromRows(List<dynamic> rows) {
     final first = rows.first;
     final List<String> rawNames =
@@ -104,15 +108,30 @@ class XLEvent extends Event {
 
     final String location = _locationFrom(rawNames);
 
-    final List<String> distances = rawNames
-        .map((name) {
-          final String remainder = _stripPrefix(name, location).trim();
-          if (remainder.isEmpty) return "";
-          final match = _distanceValue.firstMatch(remainder);
-          return match != null ? "${match.group(1)} km" : remainder;
-        })
-        .where((d) => d.isNotEmpty)
-        .toList();
+    // Per-row distance label, kept empty when a row has no distance suffix
+    // to parse (relay/single-tier events) — unlike `distances` below, this
+    // stays index-aligned with `rows` so it can be paired with each row's
+    // own e_id for the per-distance registration link.
+    final List<String> labels = rawNames.map((name) {
+      final String remainder = _stripPrefix(name, location).trim();
+      if (remainder.isEmpty) return "";
+      final match = _distanceValue.firstMatch(remainder);
+      return match != null ? "${match.group(1)} km" : remainder;
+    }).toList();
+
+    final List<String> distances = labels.where((d) => d.isNotEmpty).toList();
+
+    // The registration URL is per distance tier, since each row is its own
+    // event id on the website — not the group as a whole.
+    final List<XLRegistrationLink> registrationLinks = [];
+    for (var i = 0; i < rows.length; i++) {
+      final eventId = rows[i]["e_id"];
+      if (eventId == null) continue;
+      registrationLinks.add(XLRegistrationLink(
+        label: labels[i],
+        url: "$_registerUrlPrefix$eventId",
+      ));
+    }
 
     return XLEvent(
       id: first["e_id"],
@@ -121,8 +140,10 @@ class XLEvent extends Event {
       time: first["e_time"],
       imageUrl: _thumbnailUrl,
       location: location.isNotEmpty ? location : "XLkm Run София",
-      detailsUrl: " ",
+      detailsUrl:
+          registrationLinks.isNotEmpty ? registrationLinks.first.url : "",
       distances: distances,
+      registrationLinks: registrationLinks,
     );
   }
 
@@ -163,4 +184,14 @@ class XLEvent extends Event {
     }
     return name;
   }
+}
+
+/// One distance tier's registration link on a grouped [XLEvent] card. Each
+/// tier is its own event id on the website, so the registration URL varies
+/// per distance rather than per day/location.
+class XLRegistrationLink {
+  final String label;
+  final String url;
+
+  const XLRegistrationLink({required this.label, required this.url});
 }

--- a/fivekmrun_app_flutter/test/events/future_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/future_events_test.dart
@@ -95,4 +95,48 @@ void main() {
 
     expect(find.byType(OutlinedButton), findsNothing);
   });
+
+  testWidgets('grouped XL event shows the registration strip with header',
+      (tester) async {
+    final events = Event.listFromXLJson([
+      {
+        "e_id": 394,
+        "n_name": "с. Кътина 4.8 км",
+        "e_num": 5,
+        "e_date": 1786827600,
+        "e_time": "9:00",
+      },
+      {
+        "e_id": 395,
+        "n_name": "с. Кътина 9.6 км",
+        "e_num": 5,
+        "e_date": 1786827600,
+        "e_time": "9:00",
+      },
+    ]);
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: events)),
+        )));
+
+    expect(find.byType(XLRegistrationSection), findsOneWidget);
+    expect(find.text("Регистрация"), findsOneWidget);
+  });
+
+  testWidgets('regular event has no registration strip', (tester) async {
+    final event = Event.fromJson({
+      "e_id": 1,
+      "e_title": "Race",
+      "e_date": 1609459200,
+      "e_time": "09:00",
+      "n_name": "Sofia",
+      "e_sponsor": "",
+    });
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: [event])),
+        )));
+
+    expect(find.byType(XLRegistrationSection), findsNothing);
+  });
 }

--- a/fivekmrun_app_flutter/test/events/future_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/future_events_test.dart
@@ -51,4 +51,48 @@ void main() {
     expect(find.text("с. Кътина"), findsOneWidget);
     expect(find.text("4.8 km · 9.6 km"), findsOneWidget);
   });
+
+  testWidgets('grouped XL event shows one registration button per distance',
+      (tester) async {
+    final events = Event.listFromXLJson([
+      {
+        "e_id": 394,
+        "n_name": "с. Кътина 4.8 км",
+        "e_num": 5,
+        "e_date": 1786827600,
+        "e_time": "9:00",
+      },
+      {
+        "e_id": 395,
+        "n_name": "с. Кътина 9.6 км",
+        "e_num": 5,
+        "e_date": 1786827600,
+        "e_time": "9:00",
+      },
+    ]);
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: events)),
+        )));
+
+    expect(find.widgetWithText(OutlinedButton, "4.8 km"), findsOneWidget);
+    expect(find.widgetWithText(OutlinedButton, "9.6 km"), findsOneWidget);
+  });
+
+  testWidgets('regular event has no registration buttons', (tester) async {
+    final event = Event.fromJson({
+      "e_id": 1,
+      "e_title": "Race",
+      "e_date": 1609459200,
+      "e_time": "09:00",
+      "n_name": "Sofia",
+      "e_sponsor": "",
+    });
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: [event])),
+        )));
+
+    expect(find.byType(OutlinedButton), findsNothing);
+  });
 }

--- a/fivekmrun_app_flutter/test/state/event_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/event_model_test.dart
@@ -59,6 +59,17 @@ void main() {
       expect(e.time, "9:00");
       expect(e.imageUrl, contains("xl-run-thumbnail"));
       expect(e.date, DateTime.fromMillisecondsSinceEpoch(1786827600 * 1000));
+      expect(
+        e.registrationLinks.map((l) => l.url),
+        [
+          "https://5kmrun.bg/xlrun/event/394",
+          "https://5kmrun.bg/xlrun/event/395",
+          "https://5kmrun.bg/xlrun/event/396",
+        ],
+      );
+      expect(e.registrationLinks.map((l) => l.label),
+          ["4.8 km", "9.6 km", "14.4 km"]);
+      expect(e.detailsUrl, "https://5kmrun.bg/xlrun/event/394");
     });
 
     test('keeps separate locations/days as separate groups', () {
@@ -158,6 +169,12 @@ void main() {
       expect(e.location, "Западен парк");
       expect(e.distances, isEmpty);
       expect(e.title, "");
+      // Even with no distance label to show, the single row still gets a
+      // registration link so the button isn't silently dropped.
+      expect(e.registrationLinks, hasLength(1));
+      expect(e.registrationLinks.single.label, "");
+      expect(e.registrationLinks.single.url,
+          "https://5kmrun.bg/xlrun/event/400");
     });
   });
 


### PR DESCRIPTION
## Summary
- Populate `Event.detailsUrl` for XLrun events instead of leaving it a dead placeholder (`" "`), and add a real per-distance registration button on the grouped XL event card from #176/#183.
- Each distance tier on a grouped card (e.g. "Къса · Средна · XL" or "6.0 km · 12.0 km · 18.0 km") is its own event id on the website, so the registration URL varies per tier — not one link per card. New `XLRegistrationLink` (label + url) is built per-row in `XLEvent.fromRows`, pointing at `https://5kmrun.bg/xlrun/event/<event id>`, and `future_events.dart` renders one `OutlinedButton` per link.
- Rows with no parsed distance label (single-tier/relay events) still get a registration link — just with an empty label, rendered as a generic "Регистрация" button — so the button isn't silently dropped for those.
- Tapping a button logs `open_xlrun_registration_link` (matching the existing `open_registration_link` analytics precedent in `lib/login/login.dart`) and opens the url via `url_launcher`'s `LaunchMode.inAppWebView`. This satisfies the issue's "open in a webview" ask using the existing `url_launcher` dependency (already used elsewhere in the app) rather than adding a new webview package — no new dependency needed.

## Likely files touched (as scoped in the issue)
- `lib/state/event_model.dart` — new `XLRegistrationLink` class; `XLEvent.fromRows` now builds one per row and sets `detailsUrl` to the first link.
- `lib/events/future_events.dart` — renders the registration buttons on grouped XL cards; new `_openRegistrationLink` helper (analytics + launch).

## Test plan
- [x] `flutter analyze` on changed files — clean (3 pre-existing `unnecessary_new`/`prefer_const_constructors` infos elsewhere in the file, unrelated to this change, same ones already noted in #183).
- [x] `flutter test` — full suite passes, including new tests:
  - `test/state/event_model_test.dart` — `registrationLinks` urls/labels for a multi-tier group, `detailsUrl` populated from the first link, and a single-row group with no distance label still getting one link (empty label, real url).
  - `test/events/future_events_test.dart` — grouped XL event renders one `OutlinedButton` per distance; a regular (non-XL) event renders no registration buttons.
- [x] **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app against the live production API, logged in as an existing user.
  - Confirmed grouped XL cards ("Бонсови Поляни – Люлин планина" and "Северен парк") show one outlined button per distance tier ("Къса"/"Средна"/"XL" and "6.0 km"/"12.0 km"/"18.0 km").
  - Tapped the "XL" button on the Бонсови Поляни card — it opened an in-app webview (no app backgrounding) landing directly on that XL event's registration page (`https://5kmrun.bg/xlrun/event/<id>`), showing "XL дистанция" with "ЗАЯВИ УЧАСТИЕ" / "ЗАЯВИ ОТБОРНО УЧАСТИЕ" / "ЗАЯВИ ДОБРОВОЛЕЦ" registration options — confirming the per-distance URL routing is correct.
  - Regular (non-XL) event cards show no registration button, unaffected.
- **iOS Simulator:** not run this pass — same one-time interactive `xcode-select` prompt limitation noted in #183, not available in this automated environment.

Closes #180