### PR TITLE
KidsRun: add distinct Kids badge to future event cards

### DIFF
--- a/fivekmrun_app_flutter/lib/events/future_events.dart
+++ b/fivekmrun_app_flutter/lib/events/future_events.dart
@@ -22,6 +22,7 @@ class FutureEventsList extends StatelessWidget {
       itemBuilder: (BuildContext context, int i) {
         final Event event = events[i];
         final bool isXL = event is XLEvent;
+        final bool isKids = event is KidsEvent;
         return Card(
           child: ListTile(
             title: Row(
@@ -35,6 +36,11 @@ class FutureEventsList extends StatelessWidget {
                           padding: EdgeInsets.only(bottom: 4),
                           child: XLBadge(),
                         ),
+                      if (isKids)
+                        const Padding(
+                          padding: EdgeInsets.only(bottom: 4),
+                          child: KidsBadge(),
+                        ),
                       ListTileRow(text: event.location, icon: Icons.pin_drop),
                       ListTileRow(
                           text: dateFromat.format(event.date),
@@ -46,7 +52,11 @@ class FutureEventsList extends StatelessWidget {
                       if (event.title.isNotEmpty)
                         ListTileRow(
                             text: event.title,
-                            icon: isXL ? Icons.terrain : Icons.info),
+                            icon: isXL
+                                ? Icons.terrain
+                                : isKids
+                                    ? Icons.child_care
+                                    : Icons.info),
                     ],
                   ),
                 ),
@@ -90,6 +100,31 @@ class XLBadge extends StatelessWidget {
       ),
       child: const Text(
         "XL",
+        style: TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+          fontSize: 12.0,
+        ),
+      ),
+    );
+  }
+}
+
+/// Marks a KidsRun event card so it's visually distinguishable from regular
+/// and XL event days in the merged future-events list.
+class KidsBadge extends StatelessWidget {
+  const KidsBadge({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10.0, vertical: 4.0),
+      decoration: BoxDecoration(
+        color: Colors.green,
+        borderRadius: BorderRadius.circular(16.0),
+      ),
+      child: const Text(
+        "Kids",
         style: TextStyle(
           color: Colors.white,
           fontWeight: FontWeight.bold,

--- a/fivekmrun_app_flutter/lib/state/event_model.dart
+++ b/fivekmrun_app_flutter/lib/state/event_model.dart
@@ -26,14 +26,16 @@ class Event {
         detailsUrl = "",
         imageUrl = json["e_sponsor"];
 
-  Event.fromKidsJson(d):
-      id = d["e_id"],
-      title = d["e_title"],
-      date = DateTime.fromMillisecondsSinceEpoch(d["e_date"] * 1000),
-      time = d["e_time"],
-      imageUrl = "https://firebasestorage.googleapis.com/v0/b/kmrunbg.appspot.com/o/kids-run-bw.png?alt=media&token=a782fe29-6422-4b61-95b1-c4e7f81ddd5c",
-      location = d["n_name"],
-      detailsUrl = " ";
+  factory Event.fromKidsJson(dynamic d) => KidsEvent(
+        id: d["e_id"],
+        title: d["e_title"],
+        date: DateTime.fromMillisecondsSinceEpoch(d["e_date"] * 1000),
+        time: d["e_time"],
+        imageUrl:
+            "https://firebasestorage.googleapis.com/v0/b/kmrunbg.appspot.com/o/kids-run-bw.png?alt=media&token=a782fe29-6422-4b61-95b1-c4e7f81ddd5c",
+        location: d["n_name"],
+        detailsUrl: " ",
+      );
 
 
   static List<Event> listFromJson(dynamic json) {
@@ -163,4 +165,19 @@ class XLEvent extends Event {
     }
     return name;
   }
+}
+
+/// A KidsRun event — single-distance, unlike [XLEvent]. Exists as its own
+/// type purely so the future-events list can tell it apart from a regular
+/// or XL event and show a distinct "Kids" badge.
+class KidsEvent extends Event {
+  KidsEvent({
+    required super.id,
+    required super.title,
+    required super.date,
+    required super.time,
+    required super.imageUrl,
+    required super.location,
+    required super.detailsUrl,
+  });
 }

--- a/fivekmrun_app_flutter/test/events/future_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/future_events_test.dart
@@ -20,6 +20,7 @@ void main() {
         )));
 
     expect(find.byType(XLBadge), findsNothing);
+    expect(find.byType(KidsBadge), findsNothing);
     expect(find.text("Sofia"), findsOneWidget);
     expect(find.text("Race"), findsOneWidget);
   });
@@ -48,7 +49,30 @@ void main() {
         )));
 
     expect(find.byType(XLBadge), findsOneWidget);
+    expect(find.byType(KidsBadge), findsNothing);
     expect(find.text("с. Кътина"), findsOneWidget);
     expect(find.text("4.8 km · 9.6 km"), findsOneWidget);
+  });
+
+  testWidgets('kids event shows the Kids badge, location and title',
+      (tester) async {
+    final events = Event.listFromKidsJson([
+      {
+        "e_id": 520,
+        "n_name": "Южен Парк Kids",
+        "e_date": 1784926800,
+        "e_time": "10:00",
+        "e_title": "Детско бягане 2 км",
+      },
+    ]);
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: FutureEventsList(events: events)),
+        )));
+
+    expect(find.byType(KidsBadge), findsOneWidget);
+    expect(find.byType(XLBadge), findsNothing);
+    expect(find.text("Южен Парк Kids"), findsOneWidget);
+    expect(find.text("Детско бягане 2 км"), findsOneWidget);
   });
 }

--- a/fivekmrun_app_flutter/test/state/event_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/event_model_test.dart
@@ -174,6 +174,7 @@ void main() {
       expect(e.title, "Kids Race");
       expect(e.location, "Playground");
       expect(e.imageUrl, contains("kids-run"));
+      expect(e, isA<KidsEvent>());
     });
   });
 


### PR DESCRIPTION
## Summary
- KidsRun future events (`Event.fromKidsJson`) were already merged into the future-events list, but only distinguishable from regular/XL events by their thumbnail image — no badge/tag like the XL cards got in #176.
- `Event.fromKidsJson` is now a factory constructor returning a new `KidsEvent extends Event` type (mirroring the existing `XLEvent` pattern), purely as a marker type so the list widget can tell a Kids card apart.
- `future_events.dart` renders a green **"Kids"** badge (same pill styling as the blue `XLBadge`, different color to stay visually distinct) above the location row on Kids cards, and shows a child-care icon next to the title row (`Детско бягане N км`) instead of the generic info icon.
- KidsRun events are single-distance (confirmed in the issue and against live data), so unlike XLrun there's no grouping/tiering to handle here — this is purely the badge/visual-treatment gap called out in the issue.

## Likely files touched (as scoped in the issue)
- `lib/state/event_model.dart` — new `KidsEvent` class; `Event.fromKidsJson` converted to a factory constructor returning it.
- `lib/events/future_events.dart` — new `KidsBadge` widget; card rendering picks Kids badge/icon for `KidsEvent` instances.

## Test plan
- [x] `flutter analyze` on changed files — clean (3 pre-existing `unnecessary_new`/`prefer_const_constructors` infos elsewhere in the file, unrelated to this change).
- [x] `flutter test` — full suite passes, including new/updated tests:
  - `test/state/event_model_test.dart` — `Event.fromKidsJson` now asserted to return a `KidsEvent`.
  - `test/events/future_events_test.dart` — a Kids event renders the `KidsBadge` (and not `XLBadge`), with the parsed location/title text; existing regular/XL event tests updated to also assert `KidsBadge` is absent.
- [x] **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app against the live production API, logged in as an existing user, navigated to Събития (Events) → Предстоящи събития (Future events).
  - Confirmed Kids cards ("Южен Парк Kids", "Морска градина Варна") show the new green "Kids" badge, correct location, date/time, and "Детско бягане 2 км" title with the child-care icon.
  - Confirmed XL cards in the same list still show the blue "XL" badge as before ([#176](https://github.com/5kmrun-bg/fivekmrun-app/issues/176)/[#183](https://github.com/5kmrun-bg/fivekmrun-app/pull/183)), and regular events show neither badge — no regressions to the existing badge logic.
- **iOS Simulator:** not run this pass — same one-time interactive `xcode-select` prompt limitation noted in prior XLrun PRs, not available in this automated environment.

Closes #185