### PR TITLE
KidsRun: include Kids runs in the user's own runs list

### DIFF
--- a/fivekmrun_app_flutter/lib/constants.dart
+++ b/fivekmrun_app_flutter/lib/constants.dart
@@ -10,6 +10,7 @@ const userEndpointUrl = "https://5kmrun.bg/api/selfie/user/";
 const runsEndpointUrl = endpointBaseUrl + "user/";
 const offlineChartEndpointUrl = "https://5kmrun.bg/api/selfie/ofc/";
 const xlUserEndpointUrl = "https://5kmrun.bg/api/xlrun/user/";
+const kidsUserEndpointUrl = "https://5kmrun.bg/api/kidsrun/user/";
 
 const String key_userId = "5kmrun_UserID";
 const String key_token = "5kmrun_Token";

--- a/fivekmrun_app_flutter/lib/runs/user_runs_page.dart
+++ b/fivekmrun_app_flutter/lib/runs/user_runs_page.dart
@@ -59,7 +59,9 @@ class UserRunsList extends StatelessWidget {
                   ListTileRow(
                     icon: run.runType == RunType.xl
                         ? Icons.terrain
-                        : Icons.pin_drop,
+                        : run.runType == RunType.kids
+                            ? Icons.child_care
+                            : Icons.pin_drop,
                     text: run.location!,
                   ),
                 ListTileRow(
@@ -96,6 +98,8 @@ class RunTypePill extends StatelessWidget {
         return const SelfiePill();
       case RunType.xl:
         return const XLPill();
+      case RunType.kids:
+        return const KidsPill();
     }
   }
 }

--- a/fivekmrun_app_flutter/lib/state/run_model.dart
+++ b/fivekmrun_app_flutter/lib/state/run_model.dart
@@ -8,7 +8,7 @@ final DateFormat dateFromat = DateFormat(Constants.DATE_FORMAT);
 /// meant every consumer had to remember to exclude XL wherever it filtered
 /// on "not selfie" to mean "official". An enum makes the exclusivity
 /// structural instead of a convention every call site has to uphold.
-enum RunType { official, selfie, xl }
+enum RunType { official, selfie, xl, kids }
 
 class Run {
   final int id;
@@ -89,6 +89,31 @@ class Run {
         runType = RunType.xl,
         distance = _xlDistanceMetersFromName(json["n_name"]);
 
+  // KidsRun events are single-distance (~2 km, see #185) — unlike XLrun,
+  // n_name is already a clean location with no distance suffix to strip, so
+  // this is simpler than Run.fromXLJson: no name parsing, just a fixed
+  // distance for pace/speed.
+  static const int kidsDistanceMeters = 2000;
+
+  Run.fromKidsJson(dynamic json)
+      : id = json["r_id"],
+        eventId = json["r_eventid"],
+        date = DateTime.fromMillisecondsSinceEpoch(json["e_date"] * 1000),
+        time = timeInSecondsToString(json["r_time"]),
+        totalTime = timeInSecondsToString(json["r_time"]),
+        timeInSeconds = json["r_time"],
+        location = json["n_name"],
+        differenceFromBest = null,
+        differenceFromPrevious = null,
+        position = json["r_finish_pos"],
+        speed = timeInSecondsToSpeed(json["r_time"],
+            distanceMeters: kidsDistanceMeters),
+        notes = "",
+        pace = timeInSecondsToPace(json["r_time"],
+            distanceMeters: kidsDistanceMeters),
+        runType = RunType.kids,
+        distance = kidsDistanceMeters;
+
   static List<Run> listFromJson(Map<String, dynamic> json) {
     List<dynamic> runs = json["runners"];
     var result = List<Run>.from(runs.map((d) => Run.fromJson(d)));
@@ -137,6 +162,24 @@ class Run {
     }
 
     return byId.values.map((d) => Run.fromXLJson(d)).toList();
+  }
+
+  /// Same shape and same "runners" + "years"[].results duplication concern
+  /// as the XLrun user endpoint (see [listFromXLUserJson]) — merge and
+  /// de-dupe by r_id rather than picking just one source.
+  static List<Run> listFromKidsUserJson(dynamic json) {
+    final List<dynamic> current = (json["runners"] as List<dynamic>?) ?? [];
+    final List<dynamic> years = (json["years"] as List<dynamic>?) ?? [];
+    final List<dynamic> historic = years
+        .expand((y) => (y["results"] as List<dynamic>?) ?? const [])
+        .toList();
+
+    final Map<int, dynamic> byId = {};
+    for (final r in [...current, ...historic]) {
+      byId[r["r_id"] as int] = r;
+    }
+
+    return byId.values.map((d) => Run.fromKidsJson(d)).toList();
   }
 
   static final RegExp _xlNameDistancePattern =

--- a/fivekmrun_app_flutter/lib/state/runs_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/runs_resource.dart
@@ -62,18 +62,50 @@ class RunsResource extends ChangeNotifier {
       return this.value ?? <Run>[];
     }
 
-    final List<Run> runs;
+    // Each source is fetched independently so one endpoint failing can't
+    // blank the runs that did load — e.g. a Kids-only participant has no
+    // 5km/selfie history and that endpoint answers with a non-JSON page,
+    // which must not hide their Kids runs. Only a total failure (every
+    // source errored — a real outage) rethrows, leaving cached runs intact.
+    final List<Run> runs = [];
+    final List<Object> errors = [];
+    var anySucceeded = false;
+
     try {
-      runs = await this.retrieve5kmRuns(userId);
+      // Unlike the others, official runs aren't filtered on timeInSeconds.
+      runs.addAll(await this.retrieve5kmRuns(userId));
+      anySucceeded = true;
+    } catch (e) {
+      errors.add(e);
+    }
+
+    try {
       final List<Run> selfieRuns = await this.retrieveSelfieRuns(userId);
       runs.addAll(selfieRuns.where((r) => r.timeInSeconds != null));
+      anySucceeded = true;
+    } catch (e) {
+      errors.add(e);
+    }
+
+    try {
       final List<Run> xlRuns = await this.retrieveXLRuns(userId);
       runs.addAll(xlRuns.where((r) => r.timeInSeconds != null));
+      anySucceeded = true;
+    } catch (e) {
+      errors.add(e);
+    }
+
+    try {
       final List<Run> kidsRuns = await this.retrieveKidsRuns(userId);
       runs.addAll(kidsRuns.where((r) => r.timeInSeconds != null));
-    } catch (_) {
+      anySucceeded = true;
+    } catch (e) {
+      errors.add(e);
+    }
+
+    if (!anySucceeded) {
       this.loading = false;
-      rethrow;
+      throw errors.first;
     }
 
     this._processRuns(runs);

--- a/fivekmrun_app_flutter/lib/state/runs_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/runs_resource.dart
@@ -69,6 +69,8 @@ class RunsResource extends ChangeNotifier {
       runs.addAll(selfieRuns.where((r) => r.timeInSeconds != null));
       final List<Run> xlRuns = await this.retrieveXLRuns(userId);
       runs.addAll(xlRuns.where((r) => r.timeInSeconds != null));
+      final List<Run> kidsRuns = await this.retrieveKidsRuns(userId);
+      runs.addAll(kidsRuns.where((r) => r.timeInSeconds != null));
     } catch (_) {
       this.loading = false;
       rethrow;
@@ -114,6 +116,20 @@ class RunsResource extends ChangeNotifier {
 
     String body = utf8.decode(response.bodyBytes);
     return Run.listFromXLUserJson(jsonDecode(body));
+  }
+
+  /// Same "non-JSON error page means no history" behavior as
+  /// [retrieveXLRuns] — most users have no Kids history.
+  Future<List<Run>> retrieveKidsRuns(int? userId) async {
+    final http.Response response = await _client
+        .get(Uri.parse("${constants.kidsUserEndpointUrl}$userId"));
+
+    if (!isJsonResponse(response.statusCode, response.headers["content-type"])) {
+      return <Run>[];
+    }
+
+    String body = utf8.decode(response.bodyBytes);
+    return Run.listFromKidsUserJson(jsonDecode(body));
   }
 
   void _processRuns(List<Run> runs) {

--- a/fivekmrun_app_flutter/test/state/run_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/run_model_test.dart
@@ -204,6 +204,90 @@ void main() {
     });
   });
 
+  group('Run.fromKidsJson', () {
+    dynamic kidsResultJson({
+      String nName = "Южен Парк Kids",
+      int rTime = 720,
+    }) {
+      return {
+        "r_id": 5001,
+        "r_uid": 13731,
+        "r_eventid": 519,
+        "r_finish_pos": 12,
+        "r_time": rTime,
+        "n_name": nName,
+        "e_date": 1784322000,
+      };
+    }
+
+    test('uses "n_name" directly as the location (no distance to strip)', () {
+      final run = Run.fromKidsJson(kidsResultJson(nName: "Южен Парк Kids"));
+      expect(run.location, "Южен Парк Kids");
+    });
+
+    test('marks the run as kids with a fixed 2km distance', () {
+      final run = Run.fromKidsJson(kidsResultJson());
+      expect(run.runType, RunType.kids);
+      expect(run.distance, 2000);
+    });
+
+    test('computes pace/speed off the fixed 2km distance', () {
+      final run = Run.fromKidsJson(kidsResultJson(rTime: 600));
+      expect(run.pace, Run.timeInSecondsToPace(600, distanceMeters: 2000));
+      expect(run.speed, Run.timeInSecondsToSpeed(600, distanceMeters: 2000));
+    });
+  });
+
+  group('Run.listFromKidsUserJson', () {
+    test('merges "runners" and "years[].results", de-duplicated by r_id', () {
+      final json = {
+        "runners": [
+          {
+            "r_id": 1,
+            "r_eventid": 519,
+            "r_time": 700,
+            "r_finish_pos": 1,
+            "n_name": "Южен Парк Kids",
+            "e_date": 1784322000,
+          }
+        ],
+        "years": [
+          {
+            "yr": "2026",
+            "results": [
+              {
+                "r_id": 1, // duplicate of the "runners" entry above
+                "r_eventid": 519,
+                "r_time": 700,
+                "r_finish_pos": 1,
+                "n_name": "Южен Парк Kids",
+                "e_date": 1784322000,
+              },
+              {
+                "r_id": 2,
+                "r_eventid": 520,
+                "r_time": 650,
+                "r_finish_pos": 3,
+                "n_name": "Морска градина Варна",
+                "e_date": 1700000000,
+              },
+            ],
+          }
+        ],
+      };
+
+      final runs = Run.listFromKidsUserJson(json);
+
+      expect(runs.length, 2);
+      expect(runs.map((r) => r.id).toSet(), {1, 2});
+      expect(runs.every((r) => r.runType == RunType.kids), isTrue);
+    });
+
+    test('handles missing "runners"/"years" gracefully', () {
+      expect(Run.listFromKidsUserJson({}), isEmpty);
+    });
+  });
+
   group('Run.timeInSecondsToString', () {
     test('zero-pads minutes and seconds', () {
       expect(Run.timeInSecondsToString(0), "00:00");

--- a/fivekmrun_app_flutter/test/state/runs_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/runs_resource_test.dart
@@ -1,6 +1,5 @@
 import 'dart:convert';
 
-import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -114,12 +113,52 @@ void main() {
       expect(called, isFalse);
     });
 
-    test('rethrows FetchException and stops loading when a fetch fails',
-        () async {
+    test(
+        'tolerates a single failing source: keeps the runs that did load '
+        'instead of blanking the whole list', () async {
+      // selfie 500s, but 5km succeeds — the user should still see their
+      // 5km runs rather than an empty/error list.
       final resource = RunsResource(client: _client(selfieStatus: 500));
 
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(1));
+      expect(runs.single.runType, RunType.official);
+      expect(resource.loading, isFalse);
+    });
+
+    test(
+        'surfaces Kids runs even when the 5km and selfie endpoints answer '
+        'with non-JSON — a Kids-only participant has no 5km/selfie history, '
+        'and that must not blank their Kids runs', () async {
+      final client = MockClient((request) async {
+        if (request.url.path.contains("kidsrun")) {
+          return http.Response(jsonEncode(_kids), 200, headers: _jsonHeaders);
+        }
+        // 5km, selfie and xl all answer with a non-JSON "no history" page.
+        return http.Response("<html>no history</html>", 200,
+            headers: {"content-type": "text/html; charset=utf-8"});
+      });
+      final resource = RunsResource(client: client);
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(1));
+      expect(runs.single.runType, RunType.kids);
+      expect(resource.loading, isFalse);
+    });
+
+    test(
+        'rethrows and keeps the cached runs when every source fails '
+        '(a real outage must not wipe history)', () async {
+      final cached = [Run.fromKidsJson(_kids["runners"]![0])];
+      final resource = RunsResource(
+          client: MockClient((_) async => throw http.ClientException("down")))
+        ..value = cached;
+
       await expectLater(
-          resource.getByUserId(42), throwsA(isA<FetchException>()));
+          resource.getByUserId(42), throwsA(isA<Exception>()));
+      expect(resource.value, same(cached));
       expect(resource.loading, isFalse);
     });
 

--- a/fivekmrun_app_flutter/test/state/runs_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/runs_resource_test.dart
@@ -46,13 +46,29 @@ final _xl = {
   ]
 };
 
-/// Routes the three endpoints [getByUserId] hits to the right payload.
+final _kids = {
+  "runners": [
+    {
+      "r_id": 4,
+      "r_eventid": 519,
+      "e_date": 1784322000,
+      "r_time": 700,
+      "n_name": "Южен Парк Kids",
+      "r_finish_pos": 1,
+    }
+  ]
+};
+
+/// Routes the four endpoints [getByUserId] hits to the right payload.
 ///
-/// XL defaults to the same non-JSON "no history" response the real endpoint
-/// gives most users (see [RunsResource.retrieveXLRuns]) so existing
-/// official/selfie-only assertions don't need to account for an XL run
-/// they didn't ask for.
-MockClient _client({int selfieStatus = 200, http.Response? xlResponse}) =>
+/// XL and Kids default to the same non-JSON "no history" response the real
+/// endpoints give most users (see [RunsResource.retrieveXLRuns]/
+/// [RunsResource.retrieveKidsRuns]) so existing official/selfie-only
+/// assertions don't need to account for runs they didn't ask for.
+MockClient _client(
+        {int selfieStatus = 200,
+        http.Response? xlResponse,
+        http.Response? kidsResponse}) =>
     MockClient((request) async {
       if (request.url.path.contains("selfie")) {
         return http.Response(jsonEncode(_selfie), selfieStatus,
@@ -60,6 +76,11 @@ MockClient _client({int selfieStatus = 200, http.Response? xlResponse}) =>
       }
       if (request.url.path.contains("xlrun")) {
         return xlResponse ??
+            http.Response("<html>not found</html>", 200,
+                headers: {"content-type": "text/html; charset=utf-8"});
+      }
+      if (request.url.path.contains("kidsrun")) {
+        return kidsResponse ??
             http.Response("<html>not found</html>", 200,
                 headers: {"content-type": "text/html; charset=utf-8"});
       }
@@ -118,6 +139,30 @@ void main() {
         'treats a non-JSON XL response as "no XL runs" rather than a fetch '
         'failure — this is what the real endpoint answers for the vast '
         'majority of users who have no XL history', () async {
+      final resource = RunsResource(client: _client());
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(2));
+      expect(resource.loading, isFalse);
+    });
+
+    test('merges Kids runs in when the endpoint answers with JSON', () async {
+      final resource = RunsResource(
+          client: _client(
+              kidsResponse: http.Response(jsonEncode(_kids), 200,
+                  headers: _jsonHeaders)));
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(3));
+      expect(runs.where((r) => r.runType == RunType.kids), hasLength(1));
+    });
+
+    test(
+        'treats a non-JSON Kids response as "no Kids runs" rather than a '
+        'fetch failure — this is what the real endpoint answers for the '
+        'vast majority of users who have no Kids history', () async {
       final resource = RunsResource(client: _client());
 
       final runs = await resource.getByUserId(42);


### PR DESCRIPTION
## Summary
- Add `RunType.kids` alongside the existing `official`/`selfie`/`xl` enum (introduced in [#182](https://github.com/5kmrun-bg/fivekmrun-app/pull/182) to replace the old dual-bool `isSelfie`/`isXL` modeling), plus `Run.fromKidsJson` and `Run.listFromKidsUserJson` in `lib/state/run_model.dart`, parallel to the existing XL constructors.
- `RunsResource.getByUserId` now also fetches `api/kidsrun/user/<id>` (new `kidsUserEndpointUrl` constant) via a new `retrieveKidsRuns`, merged into the same runs list alongside official/selfie/XL. Like `retrieveXLRuns`, a non-JSON response (the real endpoint's answer for the vast majority of users with no Kids history) is treated as "no Kids runs" rather than a fetch failure, so it doesn't break the runs list for everyone else.
- KidsRun events are single-distance (~2 km, confirmed in [#185](https://github.com/5kmrun-bg/fivekmrun-app/issues/185)/[#186](https://github.com/5kmrun-bg/fivekmrun-app/issues/186)) — unlike XL, `n_name` is already a clean location with no distance suffix to parse out, so `Run.fromKidsJson` is simpler than `Run.fromXLJson`: it uses `n_name` directly as the location and a fixed 2000m for pace/speed instead of regex-parsing a distance out of the name.
- `lib/runs/user_runs_page.dart`: `UserRunsList` shows the location row with a child-care icon for Kids runs (mirroring XL's terrain icon), and `RunTypePill` gets a `RunType.kids` case with a green "Kids" pill — same green used by the Kids badge on future-event cards (#185/#186), for a consistent Kids visual language.
- No changes needed in `badges.dart`, the route charts, or `profile.dart`'s best/last official/selfie cards — they all filter by exact `RunType` equality already (not "not selfie"), so Kids runs are automatically excluded from XL/official-only logic, same as XL was in #182. `bestKidsRun`/`lastKidsRun` and a profile milestone tile are explicitly out of scope here — that's #187 (Kids profile stats), same split as XL #178/#182.

## Likely files touched (as scoped in the issue)
- `lib/state/run_model.dart` — `RunType.kids`, `Run.fromKidsJson`, `Run.listFromKidsUserJson`.
- `lib/state/runs_resource.dart` — fetch + merge Kids runs in `getByUserId`.
- `lib/runs/user_runs_page.dart` — Kids pill + icon.
- `lib/constants.dart` — new `kidsUserEndpointUrl`.

## Test plan
- [x] `flutter analyze` on changed files — no new issues (pre-existing infos elsewhere in `runs_resource.dart`/`user_runs_page.dart`/`constants.dart`, none on touched lines; verified by diffing analyzer output before/after the change).
- [x] `flutter test` — full suite passes, including new tests:
  - `test/state/run_model_test.dart` — `Run.fromKidsJson` (location from `n_name` directly, fixed 2km distance, pace/speed off that fixed distance, marks `RunType.kids`) and `Run.listFromKidsUserJson` (merge/de-dupe by `r_id` across `runners`/`years[].results`, graceful handling of missing keys).
  - `test/state/runs_resource_test.dart` — Kids runs merged in when the endpoint answers JSON; a non-JSON Kids response treated as "no Kids runs" rather than a fetch failure.
- [x] **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app against the live production API, logged in as an existing user, opened "Твоите Бягания".
  - Confirmed the existing official/selfie/XL runs still render correctly with their pills (5kmrun/Selfie/XL) — no regression from adding the fourth Kids fetch into the merge.
  - This account has no Kids run history, so the new `retrieveKidsRuns` call correctly hit the endpoint's non-JSON "no history" response and contributed zero runs — verified via the unaffected, non-crashing runs list rather than a visible Kids pill. The Kids-specific parsing/rendering logic itself (pill color, icon, `fromKidsJson`) is covered by the unit tests above rather than a live screenshot, since no test account with real Kids history was available.
- **iOS Simulator:** not run this pass — same one-time interactive `xcode-select` prompt limitation noted in prior PRs, not available in this automated environment.

Closes #188