### PR TITLE
XLrun: add engagement stats card to the profile page

### DIFF
--- a/fivekmrun_app_flutter/lib/events/future_events.dart
+++ b/fivekmrun_app_flutter/lib/events/future_events.dart
@@ -97,10 +97,16 @@ class FutureEventsList extends StatelessWidget {
 /// header, with one button per distance tier. Each button opens that tier's
 /// registration page in an in-app webview.
 class XLRegistrationSection extends StatelessWidget {
-  const XLRegistrationSection({Key? key, required this.links})
+  const XLRegistrationSection({Key? key, required this.links, this.subtitle})
       : super(key: key);
 
   final List<XLRegistrationLink> links;
+
+  /// Optional context appended to the "Регистрация" header, e.g. which event
+  /// these buttons belong to. The events tab omits it — the card above the
+  /// strip already names the event — but the profile card needs it, since
+  /// there the strip is the only thing identifying the upcoming event.
+  final String? subtitle;
 
   @override
   Widget build(BuildContext context) {
@@ -130,6 +136,17 @@ class XLRegistrationSection extends StatelessWidget {
                   letterSpacing: 0.3,
                 ),
               ),
+              if (subtitle != null)
+                Expanded(
+                  child: Text(
+                    " · ${subtitle!}",
+                    overflow: TextOverflow.ellipsis,
+                    style: const TextStyle(
+                      color: Colors.white70,
+                      fontSize: 13,
+                    ),
+                  ),
+                ),
             ],
           ),
           const SizedBox(height: 8),
@@ -166,4 +183,3 @@ class XLRegistrationSection extends StatelessWidget {
     await launchUrl(Uri.parse(url), mode: LaunchMode.inAppWebView);
   }
 }
-

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -13,6 +13,7 @@ import 'package:fivekmrun_flutter/custom_icons.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:fivekmrun_flutter/state/xl_stats.dart';
 import 'package:fivekmrun_flutter/timekeeping/timekeeping.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
@@ -39,6 +40,7 @@ class ProfileDashboard extends StatelessWidget {
         runs.where((r) => r.runType == RunType.official).length > 0;
     final hasSelfieRuns = runs != null &&
         runs.where((r) => r.runType == RunType.selfie).length > 0;
+    final xlStats = XLStats.fromRuns(runs ?? <Run>[]);
 
     final goToSettings = () {
       Navigator.of(context, rootNavigator: true).pushNamed("settings");
@@ -184,6 +186,7 @@ class ProfileDashboard extends StatelessWidget {
                 if (hasSelfieRuns)
                   this.buildRunsCards(
                       runsRes.bestSelfieRun!, runsRes.lastSelfieRun!, "selfie"),
+                if (xlStats != null) this.buildXLStatsCard(xlStats),
                 if (hasAnyRuns) this.buildRunsChartCard(runs),
                 if (!runsRes.loading && !hasAnyRuns)
                   Row(
@@ -221,6 +224,59 @@ class ProfileDashboard extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+
+  Widget buildXLStatsCard(XLStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Builder(builder: (context) {
+          final theme = Theme.of(context);
+          final labelStyle = theme.textTheme.bodyMedium;
+          final valueStyle = theme.textTheme.titleLarge
+              ?.copyWith(color: theme.colorScheme.secondary);
+
+          Widget stat(String value, String label) {
+            return Column(
+              children: <Widget>[
+                Text(value, style: valueStyle),
+                Text(label, style: labelStyle, textAlign: TextAlign.center),
+              ],
+            );
+          }
+
+          final km = stats.totalDistanceMeters != null
+              ? (stats.totalDistanceMeters! / 1000).toStringAsFixed(1)
+              : null;
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text("XLrun", style: theme.textTheme.titleSmall),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  stat(stats.runsThisYear.toString(), "тази година"),
+                  stat(stats.runsAllTime.toString(), "общо"),
+                  if (km != null) stat(km, "км общо"),
+                ],
+              ),
+              if (stats.mostRecentRun != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    (stats.mostRecentRun!.location ?? "").isNotEmpty
+                        ? "Последно: ${stats.mostRecentRun!.displayDate} · ${stats.mostRecentRun!.location}"
+                        : "Последно: ${stats.mostRecentRun!.displayDate}",
+                    style: labelStyle,
+                  ),
+                ),
+            ],
+          );
+        }),
+      ),
     );
   }
 

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -10,6 +10,11 @@ import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/run_card.dart';
 import 'package:fivekmrun_flutter/constants.dart';
 import 'package:fivekmrun_flutter/custom_icons.dart';
+import 'package:fivekmrun_flutter/events/future_events.dart'
+    show XLRegistrationSection;
+import 'package:fivekmrun_flutter/home.dart';
+import 'package:fivekmrun_flutter/state/event_model.dart';
+import 'package:fivekmrun_flutter/state/events_resource.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
@@ -41,6 +46,13 @@ class ProfileDashboard extends StatelessWidget {
     final hasSelfieRuns = runs != null &&
         runs.where((r) => r.runType == RunType.selfie).length > 0;
     final xlStats = XLStats.fromRuns(runs ?? <Run>[]);
+    // Promote the next XL event to anyone who has ever run one. The events
+    // are already fetched for the events tab (AllFutureEventsResource is
+    // loaded on home), so this adds no request.
+    final nextXLEvent = xlStats == null
+        ? null
+        : nextUpcomingXLEvent(
+            Provider.of<AllFutureEventsResource>(context).value);
 
     final goToSettings = () {
       Navigator.of(context, rootNavigator: true).pushNamed("settings");
@@ -158,8 +170,8 @@ class ProfileDashboard extends StatelessWidget {
                           ]),
                           MilestoneTile(
                               value: runsRes.value
-                                      ?.where((r) =>
-                                          r.runType == RunType.official)
+                                      ?.where(
+                                          (r) => r.runType == RunType.official)
                                       .length
                                       .toInt() ??
                                   0,
@@ -186,7 +198,8 @@ class ProfileDashboard extends StatelessWidget {
                 if (hasSelfieRuns)
                   this.buildRunsCards(
                       runsRes.bestSelfieRun!, runsRes.lastSelfieRun!, "selfie"),
-                if (xlStats != null) this.buildXLStatsCard(xlStats),
+                if (xlStats != null)
+                  this.buildXLStatsCard(xlStats, nextXLEvent),
                 if (hasAnyRuns) this.buildRunsChartCard(runs),
                 if (!runsRes.loading && !hasAnyRuns)
                   Row(
@@ -227,55 +240,154 @@ class ProfileDashboard extends StatelessWidget {
     );
   }
 
-  Widget buildXLStatsCard(XLStats stats) {
+  Widget buildXLStatsCard(XLStats stats, XLEvent? nextEvent) {
     return Card(
-      child: Padding(
-        padding: const EdgeInsets.all(12.0),
-        child: Builder(builder: (context) {
-          final theme = Theme.of(context);
-          final labelStyle = theme.textTheme.bodyMedium;
-          final valueStyle = theme.textTheme.titleLarge
-              ?.copyWith(color: theme.colorScheme.secondary);
+      clipBehavior: Clip.antiAlias,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.all(12.0),
+            child: Builder(builder: (context) {
+              final theme = Theme.of(context);
+              final labelStyle = theme.textTheme.bodyMedium;
+              final valueStyle = theme.textTheme.titleLarge
+                  ?.copyWith(color: theme.colorScheme.secondary);
 
-          Widget stat(String value, String label) {
-            return Column(
-              children: <Widget>[
-                Text(value, style: valueStyle),
-                Text(label, style: labelStyle, textAlign: TextAlign.center),
-              ],
-            );
-          }
+              Widget stat(String value, String label) {
+                return Column(
+                  children: <Widget>[
+                    Text(value, style: valueStyle),
+                    Text(label, style: labelStyle, textAlign: TextAlign.center),
+                  ],
+                );
+              }
 
-          final km = stats.totalDistanceMeters != null
-              ? (stats.totalDistanceMeters! / 1000).toStringAsFixed(1)
-              : null;
+              // Deliberately lighter than ListTileRow (which styles tile
+              // *titles*): this is secondary context under the stats, so it
+              // uses a smaller icon and smaller body text.
+              final rowTextStyle =
+                  theme.textTheme.bodySmall?.copyWith(color: Colors.white);
 
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: <Widget>[
-              Text("XLrun", style: theme.textTheme.titleSmall),
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                children: <Widget>[
-                  stat(stats.runsThisYear.toString(), "тази година"),
-                  stat(stats.runsAllTime.toString(), "общо"),
-                  if (km != null) stat(km, "км общо"),
-                ],
-              ),
-              if (stats.mostRecentRun != null)
-                Padding(
-                  padding: const EdgeInsets.only(top: 8.0),
-                  child: Text(
-                    (stats.mostRecentRun!.location ?? "").isNotEmpty
-                        ? "Последно: ${stats.mostRecentRun!.displayDate} · ${stats.mostRecentRun!.location}"
-                        : "Последно: ${stats.mostRecentRun!.displayDate}",
-                    style: labelStyle,
+              // [label] is always plain text; only [linkText] is tappable,
+              // and only it carries the chevron marking the row as a link.
+              Widget metaRow(IconData icon, String label,
+                  {String? linkText, VoidCallback? onTap}) {
+                return Padding(
+                  // The extra 4 on the left lines this row up with the
+                  // registration strip below, which sits outside the card's
+                  // 12px padding and uses 16 of its own.
+                  padding: const EdgeInsets.fromLTRB(4, 3, 0, 3),
+                  child: Row(
+                    children: <Widget>[
+                      // Boxed to the registration header's 18px icon width so
+                      // both labels start at the same x, while the glyph
+                      // itself stays smaller and less prominent.
+                      SizedBox(
+                        width: 18,
+                        child: Icon(icon,
+                            size: 14, color: theme.colorScheme.secondary),
+                      ),
+                      const SizedBox(width: 6),
+                      Text(
+                        label,
+                        style: theme.textTheme.bodySmall?.copyWith(
+                          color: theme.colorScheme.secondary,
+                          fontWeight: FontWeight.bold,
+                        ),
+                      ),
+                      if (linkText != null)
+                        Flexible(
+                          child: InkWell(
+                            onTap: onTap,
+                            child: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                Flexible(
+                                  child: Text(
+                                    linkText,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: rowTextStyle,
+                                  ),
+                                ),
+                                // The chevron is what actually marks this as
+                                // tappable — colour alone reads as emphasis.
+                                Icon(Icons.chevron_right,
+                                    size: 16,
+                                    color: theme.colorScheme.secondary),
+                              ],
+                            ),
+                          ),
+                        ),
+                    ],
                   ),
-                ),
-            ],
-          );
-        }),
+                );
+              }
+
+              String? km(int? meters) =>
+                  meters != null ? (meters / 1000).toStringAsFixed(1) : null;
+
+              final kmThisYear = km(stats.distanceThisYearMeters);
+              final kmAllTime = km(stats.totalDistanceMeters);
+
+              final lastRun = stats.mostRecentRun;
+
+              return Column(
+                children: <Widget>[
+                  Text("XLrun", style: theme.textTheme.titleSmall),
+                  const SizedBox(height: 8),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                    children: <Widget>[
+                      // The this-year pair is hidden entirely when there are no
+                      // runs this year — showing "0 тази година" next to a hidden
+                      // "км тази година" reads as inconsistent.
+                      if (stats.runsThisYear > 0) ...<Widget>[
+                        Expanded(
+                            child: stat(
+                                stats.runsThisYear.toString(), "тази година")),
+                        if (kmThisYear != null)
+                          Expanded(child: stat(kmThisYear, "км тази година")),
+                      ],
+                      Expanded(
+                          child: stat(stats.runsAllTime.toString(), "общо")),
+                      if (kmAllTime != null)
+                        Expanded(child: stat(kmAllTime, "км общо")),
+                    ],
+                  ),
+                  // Splits the card into its two halves: the aggregate
+                  // numbers above, the last run below.
+                  if (lastRun != null) const Divider(height: 20),
+                  if (lastRun != null)
+                    metaRow(
+                      Icons.terrain,
+                      "Последно: ",
+                      linkText: (lastRun.location ?? "").isNotEmpty
+                          ? "${lastRun.displayDate} · ${lastRun.location}"
+                          : lastRun.displayDate,
+                      onTap: () {
+                        final tabHelper = Provider.of<TabNavigationHelper>(
+                            context,
+                            listen: false);
+                        tabHelper.selectTab(AppTab.runs);
+                        tabHelper.pushToTab(AppTab.runs, "/run-details",
+                            arguments: lastRun);
+                      },
+                    ),
+                ],
+              );
+            }),
+          ),
+          // The strip doubles as the "next event" teaser here: its header
+          // carries the event's location and date, so no separate line is
+          // needed above it.
+          if (nextEvent != null && nextEvent.registrationLinks.isNotEmpty)
+            XLRegistrationSection(
+              links: nextEvent.registrationLinks,
+              subtitle:
+                  "${nextEvent.location}, ${dateFromat.format(nextEvent.date)}",
+            ),
+        ],
       ),
     );
   }

--- a/fivekmrun_app_flutter/lib/state/xl_stats.dart
+++ b/fivekmrun_app_flutter/lib/state/xl_stats.dart
@@ -1,0 +1,59 @@
+import 'package:fivekmrun_flutter/state/run_model.dart';
+
+/// Aggregate XLrun engagement stats for the profile page, derived from the
+/// user's already-fetched runs list (RunsResource) rather than a second
+/// fetch against xlrun/user/<id> — RunsResource already hits that endpoint
+/// to build "Твоите бягания" (#179), so calling it again here would just
+/// duplicate the same request for data already in memory.
+///
+/// Elevation isn't included: the endpoint carries no elevation field
+/// anywhere (confirmed in #178), so it isn't buildable without a backend
+/// addition. "Best XL finish time" is also left out deliberately — XL
+/// events vary in distance, so a single fastest raw time isn't a meaningful
+/// "best" across them the way it is for the fixed-distance official/selfie
+/// stats, and there's no reliable way to derive whatever normalization the
+/// backend's own `min`/`avg`/`max` aggregates use from the runs list alone.
+class XLStats {
+  final int runsThisYear;
+  final int runsAllTime;
+  final int? totalDistanceMeters;
+  final Run? mostRecentRun;
+
+  const XLStats({
+    required this.runsThisYear,
+    required this.runsAllTime,
+    required this.totalDistanceMeters,
+    required this.mostRecentRun,
+  });
+
+  /// Returns null if the user has no XL history, so callers can skip
+  /// rendering the stat card entirely rather than showing all-zero stats.
+  static XLStats? fromRuns(List<Run> allRuns) {
+    final xlRuns = allRuns.where((r) => r.runType == RunType.xl).toList();
+    if (xlRuns.isEmpty) {
+      return null;
+    }
+
+    xlRuns.sort(
+        (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
+
+    final currentYear = DateTime.now().year;
+    final runsThisYear =
+        xlRuns.where((r) => r.date?.year == currentYear).length;
+
+    // Only runs whose distance was successfully parsed out of "n_name"
+    // contribute — an unparseable name means an unknown distance, not a
+    // zero one, so it's excluded rather than treated as 0km.
+    final parsedDistances = xlRuns.map((r) => r.distance).whereType<int>();
+    final totalDistanceMeters = parsedDistances.isEmpty
+        ? null
+        : parsedDistances.reduce((a, b) => a + b);
+
+    return XLStats(
+      runsThisYear: runsThisYear,
+      runsAllTime: xlRuns.length,
+      totalDistanceMeters: totalDistanceMeters,
+      mostRecentRun: xlRuns.first,
+    );
+  }
+}

--- a/fivekmrun_app_flutter/lib/state/xl_stats.dart
+++ b/fivekmrun_app_flutter/lib/state/xl_stats.dart
@@ -1,4 +1,21 @@
+import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
+
+/// The soonest upcoming XL event, or null if none is scheduled. Today's
+/// event still counts as upcoming — it's compared by day, not by timestamp,
+/// because the event's start time lives in a separate `time` string.
+XLEvent? nextUpcomingXLEvent(List<Event> events, {DateTime? now}) {
+  final today = now ?? DateTime.now();
+  final startOfToday = DateTime(today.year, today.month, today.day);
+
+  final upcoming = events
+      .whereType<XLEvent>()
+      .where((e) => !e.date.isBefore(startOfToday))
+      .toList()
+    ..sort((a, b) => a.date.compareTo(b.date));
+
+  return upcoming.isEmpty ? null : upcoming.first;
+}
 
 /// Aggregate XLrun engagement stats for the profile page, derived from the
 /// user's already-fetched runs list (RunsResource) rather than a second
@@ -16,12 +33,14 @@ import 'package:fivekmrun_flutter/state/run_model.dart';
 class XLStats {
   final int runsThisYear;
   final int runsAllTime;
+  final int? distanceThisYearMeters;
   final int? totalDistanceMeters;
   final Run? mostRecentRun;
 
   const XLStats({
     required this.runsThisYear,
     required this.runsAllTime,
+    required this.distanceThisYearMeters,
     required this.totalDistanceMeters,
     required this.mostRecentRun,
   });
@@ -38,21 +57,22 @@ class XLStats {
         (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
 
     final currentYear = DateTime.now().year;
-    final runsThisYear =
-        xlRuns.where((r) => r.date?.year == currentYear).length;
+    final thisYearRuns =
+        xlRuns.where((r) => r.date?.year == currentYear).toList();
 
     // Only runs whose distance was successfully parsed out of "n_name"
     // contribute — an unparseable name means an unknown distance, not a
     // zero one, so it's excluded rather than treated as 0km.
-    final parsedDistances = xlRuns.map((r) => r.distance).whereType<int>();
-    final totalDistanceMeters = parsedDistances.isEmpty
-        ? null
-        : parsedDistances.reduce((a, b) => a + b);
+    int? sumDistance(List<Run> runs) {
+      final parsed = runs.map((r) => r.distance).whereType<int>();
+      return parsed.isEmpty ? null : parsed.reduce((a, b) => a + b);
+    }
 
     return XLStats(
-      runsThisYear: runsThisYear,
+      runsThisYear: thisYearRuns.length,
       runsAllTime: xlRuns.length,
-      totalDistanceMeters: totalDistanceMeters,
+      distanceThisYearMeters: sumDistance(thisYearRuns),
+      totalDistanceMeters: sumDistance(xlRuns),
       mostRecentRun: xlRuns.first,
     );
   }

--- a/fivekmrun_app_flutter/test/state/xl_stats_test.dart
+++ b/fivekmrun_app_flutter/test/state/xl_stats_test.dart
@@ -1,0 +1,108 @@
+import 'package:fivekmrun_flutter/state/run_model.dart';
+import 'package:fivekmrun_flutter/state/xl_stats.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('XLStats.fromRuns', () {
+    dynamic xlJson({
+      required int rId,
+      required String nName,
+      required int eDate,
+      int rTime = 3766,
+    }) {
+      return {
+        "r_id": rId,
+        "r_uid": 1,
+        "r_eventid": 1,
+        "r_finish_pos": 1,
+        "r_time": rTime,
+        "n_name": nName,
+        "e_date": eDate,
+      };
+    }
+
+    test('returns null when the user has no XL runs', () {
+      final runs = [
+        Run.fromJson({
+          "r_id": 1,
+          "r_eventid": 1,
+          "e_date": 1609459200,
+          "r_time": 1500,
+          "n_name": "Sofia",
+          "r_finish_pos": 1,
+        }),
+      ];
+
+      expect(XLStats.fromRuns(runs), isNull);
+    });
+
+    test('counts all-time and this-year runs, ignoring non-XL runs', () {
+      final now = DateTime.now();
+      final thisYearEpoch =
+          DateTime(now.year, 6, 1).millisecondsSinceEpoch ~/ 1000;
+
+      final runs = [
+        Run.fromJson({
+          "r_id": 1,
+          "r_eventid": 1,
+          "e_date": 1609459200,
+          "r_time": 1500,
+          "n_name": "Sofia",
+          "r_finish_pos": 1,
+        }),
+        Run.fromXLJson(
+            xlJson(rId: 2, nName: "Сеславци 7.6 км", eDate: thisYearEpoch)),
+        Run.fromXLJson(
+            xlJson(rId: 3, nName: "Бистрица 10.0 км", eDate: 1600000000)),
+      ];
+
+      final stats = XLStats.fromRuns(runs)!;
+
+      expect(stats.runsAllTime, 2);
+      expect(stats.runsThisYear, 1);
+    });
+
+    test('sums only distances that were parsed out of "n_name"', () {
+      final runs = [
+        Run.fromXLJson(
+            xlJson(rId: 1, nName: "Сеславци 7.6 км", eDate: 1700000000)),
+        Run.fromXLJson(
+            xlJson(rId: 2, nName: "Бистрица 10.0 км", eDate: 1700000001)),
+        // Unparseable name — contributes no distance, but still counts as a
+        // run, and must not make the total look like a 0km run happened.
+        Run.fromXLJson(
+            xlJson(rId: 3, nName: "Some Unexpected Text", eDate: 1700000002)),
+      ];
+
+      final stats = XLStats.fromRuns(runs)!;
+
+      expect(stats.runsAllTime, 3);
+      expect(stats.totalDistanceMeters, 17600);
+    });
+
+    test('total distance is null when no XL run has a parseable distance',
+        () {
+      final runs = [
+        Run.fromXLJson(
+            xlJson(rId: 1, nName: "Some Unexpected Text", eDate: 1700000000)),
+      ];
+
+      final stats = XLStats.fromRuns(runs)!;
+
+      expect(stats.totalDistanceMeters, isNull);
+    });
+
+    test('most recent run is the latest by date, not by insertion order', () {
+      final runs = [
+        Run.fromXLJson(
+            xlJson(rId: 1, nName: "Older 5.0 км", eDate: 1600000000)),
+        Run.fromXLJson(
+            xlJson(rId: 2, nName: "Newer 10.0 км", eDate: 1700000000)),
+      ];
+
+      final stats = XLStats.fromRuns(runs)!;
+
+      expect(stats.mostRecentRun!.location, "Newer");
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/xl_stats_test.dart
+++ b/fivekmrun_app_flutter/test/state/xl_stats_test.dart
@@ -1,3 +1,4 @@
+import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:fivekmrun_flutter/state/xl_stats.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -62,6 +63,40 @@ void main() {
       expect(stats.runsThisYear, 1);
     });
 
+    test('sums this-year distance separately from the all-time total', () {
+      final now = DateTime.now();
+      final thisYearEpoch =
+          DateTime(now.year, 6, 1).millisecondsSinceEpoch ~/ 1000;
+
+      final runs = [
+        Run.fromXLJson(
+            xlJson(rId: 1, nName: "Сеславци 7.6 км", eDate: thisYearEpoch)),
+        Run.fromXLJson(
+            xlJson(rId: 2, nName: "Бистрица 10.0 км", eDate: thisYearEpoch)),
+        // Previous year — counts towards the all-time total only.
+        Run.fromXLJson(
+            xlJson(rId: 3, nName: "Витоша 5.0 км", eDate: 1600000000)),
+      ];
+
+      final stats = XLStats.fromRuns(runs)!;
+
+      expect(stats.distanceThisYearMeters, 17600);
+      expect(stats.totalDistanceMeters, 22600);
+    });
+
+    test('this-year distance is null when there are no runs this year', () {
+      final runs = [
+        Run.fromXLJson(
+            xlJson(rId: 1, nName: "Витоша 5.0 км", eDate: 1600000000)),
+      ];
+
+      final stats = XLStats.fromRuns(runs)!;
+
+      expect(stats.runsThisYear, 0);
+      expect(stats.distanceThisYearMeters, isNull);
+      expect(stats.totalDistanceMeters, 5000);
+    });
+
     test('sums only distances that were parsed out of "n_name"', () {
       final runs = [
         Run.fromXLJson(
@@ -80,8 +115,7 @@ void main() {
       expect(stats.totalDistanceMeters, 17600);
     });
 
-    test('total distance is null when no XL run has a parseable distance',
-        () {
+    test('total distance is null when no XL run has a parseable distance', () {
       final runs = [
         Run.fromXLJson(
             xlJson(rId: 1, nName: "Some Unexpected Text", eDate: 1700000000)),
@@ -103,6 +137,75 @@ void main() {
       final stats = XLStats.fromRuns(runs)!;
 
       expect(stats.mostRecentRun!.location, "Newer");
+    });
+  });
+
+  group('nextUpcomingXLEvent', () {
+    final now = DateTime(2026, 7, 26, 14, 0);
+
+    dynamic xlEventRow({required int id, required DateTime date}) {
+      return {
+        "e_id": id,
+        "e_num": id,
+        "n_name": "с. Кътина 4.8 км",
+        "e_date": date.millisecondsSinceEpoch ~/ 1000,
+        "e_time": "9:00",
+      };
+    }
+
+    XLEvent xlEvent({required int id, required DateTime date}) {
+      return Event.listFromXLJson([xlEventRow(id: id, date: date)]).first
+          as XLEvent;
+    }
+
+    test('returns null when there are no XL events at all', () {
+      expect(nextUpcomingXLEvent(<Event>[], now: now), isNull);
+    });
+
+    test('returns null when every XL event is in the past', () {
+      final events = <Event>[
+        xlEvent(id: 1, date: DateTime(2026, 7, 1)),
+        xlEvent(id: 2, date: DateTime(2026, 6, 1)),
+      ];
+
+      expect(nextUpcomingXLEvent(events, now: now), isNull);
+    });
+
+    test('picks the soonest upcoming event regardless of list order', () {
+      final events = <Event>[
+        xlEvent(id: 1, date: DateTime(2026, 9, 5)),
+        xlEvent(id: 2, date: DateTime(2026, 8, 1)),
+        xlEvent(id: 3, date: DateTime(2026, 7, 1)),
+      ];
+
+      expect(nextUpcomingXLEvent(events, now: now)!.id, 2);
+    });
+
+    test("today's event still counts as upcoming", () {
+      final events = <Event>[
+        xlEvent(id: 1, date: DateTime(2026, 7, 26, 9, 0)),
+        xlEvent(id: 2, date: DateTime(2026, 8, 1)),
+      ];
+
+      expect(nextUpcomingXLEvent(events, now: now)!.id, 1);
+    });
+
+    test('ignores non-XL events', () {
+      final events = <Event>[
+        ...Event.listFromJson([
+          {
+            "e_id": 99,
+            "e_title": "Редовно бягане",
+            "e_date": DateTime(2026, 7, 27).millisecondsSinceEpoch ~/ 1000,
+            "e_time": "9:00",
+            "n_name": "Южен парк",
+            "e_sponsor": "",
+          }
+        ]),
+        xlEvent(id: 2, date: DateTime(2026, 8, 1)),
+      ];
+
+      expect(nextUpcomingXLEvent(events, now: now)!.id, 2);
     });
   });
 }


### PR DESCRIPTION
## Summary

Adds an `XLrun` card to the profile page, shown only to users with XL run history, and uses it to promote XLrun: aggregate stats up top, the last run below, and the next event's registration strip at the bottom.

```
              XLrun
   4      35.5     19     189.1
тази..  км тази..  общо  км общо
──────────────────────────────────
⛰ Последно: 12.07.2026 · Сеславци ›
──────────────────────────────────
⊕ РЕГИСТРАЦИЯ · с. Кътина, 14.08.2026
[ Къса ] [ Средна ] [ XL ]
```

### Stats

- New `XLStats` model (`lib/state/xl_stats.dart`) with a pure `XLStats.fromRuns(List<Run>)` factory — **no new network call**. `RunsResource` already fetches `xlrun/user/<id>` to build the XL entries in "Твоите бягания" ([#179](https://github.com/5kmrun-bg/fivekmrun-app/pull/179)), so the stats are derived from data already in memory.
- Runs and distance, both this year and all-time. Distances come from each XL run's already-parsed `Run.distance`; runs whose distance couldn't be parsed out of `n_name` are excluded from the total rather than counted as 0km, and the total is `null` (column omitted) when nothing parsed.
- The this-year pair (runs + km) is hidden **together** when there are no runs this year, so you never get "0 тази година" next to an absent km figure.
- `XLStats.fromRuns` returns `null` when the user has no XL runs, so the card simply isn't rendered — no all-zero placeholder.

### Last run

- The date + location tap through to that run's details, reusing the navigation `RunCard` already uses (`selectTab(AppTab.runs)` + `pushToTab("/run-details")`). Only the title is the link; the "Последно:" label is not.

### Next event + registration

- Reuses the events tab's own `XLRegistrationSection` rather than a look-alike, so the registration buttons stay identical in both places. `XLRegistrationSection` gains an optional `subtitle`, used here to carry the event's location and date in its header; the events tab passes none, so **its strip is unchanged**.
- The event comes from `nextUpcomingXLEvent()` reading the already-loaded `AllFutureEventsResource` — again **no extra request**. Today's event still counts as upcoming, compared by day since the start time is a separate `e_time` string.

### Visual consistency

- Card heading centred, matching the other profile cards.
- The last-run row is styled deliberately lighter than `ListTileRow` (which styles tile *titles*) — it's secondary context under the stats — with a red bold label, white regular title, and a chevron marking the tap target.
- A divider separates the aggregate numbers from the last-run row, and that row's icon and label are aligned to the registration strip's left offset (both labels start at 40px from the card edge).

## Deliberately out of scope (per the issue's own guidance)

- **Elevation** — the endpoint carries no elevation field anywhere; not buildable without a backend addition.
- **"Best XL finish time"** — listed in the issue as a "proposed additional metric," not required. XL events vary in distance, so a single fastest raw time isn't a meaningful "best" the way it is for the fixed-distance official/selfie stats.

## Files touched

- `lib/state/xl_stats.dart` — new `XLStats` model and `nextUpcomingXLEvent()`.
- `lib/profile.dart` — new `buildXLStatsCard`, wired in between the run-type cards and the runs chart.
- `lib/events/future_events.dart` — optional `subtitle` on `XLRegistrationSection`.

## Test plan

- [x] `flutter analyze` on the changed files — no errors or warnings (only pre-existing style infos).
- [x] `flutter test` — full suite passes, including 12 cases in `test/state/xl_stats_test.dart`:
  - `XLStats.fromRuns`: returns `null` with no XL runs; counts all-time vs. this-year runs ignoring non-XL runs; sums this-year distance separately from all-time; this-year distance `null` when there are no runs this year; sums only parseable distances; total `null` when nothing parsed; most recent run picked by date, not insertion order.
  - `nextUpcomingXLEvent`: `null` with no events; `null` when all are past; soonest picked regardless of list order; today's event still counts; non-XL events ignored.
- [x] **Manual verification — iOS Simulator (iPhone 16e, iOS 18.6):** built and ran against the live production API as a user with real XL history. Card renders with real data — **4** runs this year, **19** all-time, **189.1 км общо**, "Последно: 12.07.2026 · Сеславци" — matching that account's XL entries in "Твоите бягания". No layout regressions to the selfie/official cards, milestone tiles, or charts around it.
- [x] **Android emulator (Pixel 7 API 36):** verified for the original stat card.
- [x] **No XL history:** manually confirmed the card is absent entirely for a user with no XL runs — no all-zero placeholder.

Closes #178
