### PR TITLE
XLrun: add past results/leaderboards, one item per distance tier

### DIFF
--- a/fivekmrun_app_flutter/lib/common/refresh_helper.dart
+++ b/fivekmrun_app_flutter/lib/common/refresh_helper.dart
@@ -24,7 +24,8 @@ Future<void> refreshAllData(BuildContext context) async {
   final runsRes = Provider.of<RunsResource>(context, listen: false);
   final futureEventsRes =
       Provider.of<AllFutureEventsResource>(context, listen: false);
-  final pastEventsRes = Provider.of<PastEventsResource>(context, listen: false);
+  final pastEventsRes =
+      Provider.of<AllPastEventsResource>(context, listen: false);
 
   // eagerError: false — one unreachable endpoint shouldn't abandon the others.
   await Future.wait(

--- a/fivekmrun_app_flutter/lib/constants.dart
+++ b/fivekmrun_app_flutter/lib/constants.dart
@@ -2,6 +2,8 @@ const pastEventsUrl = "https://5kmrun.bg/api/5kmrun/results";
 const futureEventsUrl = "https://5kmrun.bg/api/5kmrun/events";
 const resultEventsUrl = "https://5kmrun.bg/api/5kmrun/result/";
 const xlFutureEventsUrl = "https://5kmrun.bg/api/xlrun/events";
+const xlPastEventsUrl = "https://5kmrun.bg/api/xlrun/results";
+const xlResultEventsUrl = "https://5kmrun.bg/api/xlrun/result/";
 const kidsFutureEventsUrl = "https://5kmrun.bg/api/kidsrun/events";
 const wrapUrl = "https://wrapped.5kmrun.bg/";
 

--- a/fivekmrun_app_flutter/lib/events/event_results_page.dart
+++ b/fivekmrun_app_flutter/lib/events/event_results_page.dart
@@ -1,4 +1,5 @@
 import 'package:fivekmrun_flutter/common/results_list.dart';
+import 'package:fivekmrun_flutter/constants.dart' as constants;
 import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:fivekmrun_flutter/state/result_model.dart';
 import 'package:fivekmrun_flutter/state/results_resource.dart';
@@ -17,11 +18,13 @@ class _EventResultsPageState extends State<EventResultsPage> {
   @override
   Widget build(BuildContext context) {
     Event event = ModalRoute.of(context)?.settings.arguments as Event;
+    final bool isXL = event is XLEvent;
 
     return Scaffold(
       appBar: AppBar(title: Text("Резултати")),
       body: FutureBuilder<List<Result>>(
-        future: results.getAll(event.id),
+        future: results.getAll(event.id,
+            baseUrl: isXL ? constants.xlResultEventsUrl : null),
         initialData: [],
         builder: (BuildContext context, AsyncSnapshot<List<Result>> snapshot) {
           switch (snapshot.connectionState) {

--- a/fivekmrun_app_flutter/lib/events/events_page.dart
+++ b/fivekmrun_app_flutter/lib/events/events_page.dart
@@ -30,7 +30,7 @@ class _EventsPage extends State<EventsPage> {
     if (!this.futureEventSelected) {
       return RefreshIndicator(
         onRefresh: () => refreshAllData(context),
-        child: Consumer<PastEventsResource>(
+        child: Consumer<AllPastEventsResource>(
           builder: (context, eventsResource, child) {
             if (eventsResource.loading) {
               return refreshableMessage(CircularProgressIndicator());

--- a/fivekmrun_app_flutter/lib/events/past_events.dart
+++ b/fivekmrun_app_flutter/lib/events/past_events.dart
@@ -1,6 +1,6 @@
 import 'package:fivekmrun_flutter/common/constants.dart';
 import 'package:fivekmrun_flutter/common/list_tile_row.dart';
-import 'package:fivekmrun_flutter/events/future_events.dart' show XLBadge;
+import 'package:fivekmrun_flutter/common/pill.dart';
 import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -39,7 +39,7 @@ class PastEventsList extends StatelessWidget {
                       if (isXL)
                         const Padding(
                           padding: EdgeInsets.only(bottom: 4),
-                          child: XLBadge(),
+                          child: XLPill(),
                         ),
                       ListTileRow(
                           text: events[i].location, icon: Icons.pin_drop),

--- a/fivekmrun_app_flutter/lib/events/past_events.dart
+++ b/fivekmrun_app_flutter/lib/events/past_events.dart
@@ -1,5 +1,6 @@
 import 'package:fivekmrun_flutter/common/constants.dart';
 import 'package:fivekmrun_flutter/common/list_tile_row.dart';
+import 'package:fivekmrun_flutter/events/future_events.dart' show XLBadge;
 import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
@@ -20,6 +21,9 @@ class PastEventsList extends StatelessWidget {
       physics: const AlwaysScrollableScrollPhysics(),
       itemCount: events.length,
       itemBuilder: (BuildContext context, int i) {
+        final Event event = events[i];
+        final bool isXL = event is XLEvent;
+
         return Card(
           child: ListTile(
             onTap: () => Navigator.of(context).pushNamed(
@@ -32,13 +36,20 @@ class PastEventsList extends StatelessWidget {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: <Widget>[
+                      if (isXL)
+                        const Padding(
+                          padding: EdgeInsets.only(bottom: 4),
+                          child: XLBadge(),
+                        ),
                       ListTileRow(
                           text: events[i].location, icon: Icons.pin_drop),
                       ListTileRow(
                           text: dateFromat.format(events[i].date),
                           icon: Icons.calendar_today),
                       if (events[i].title != "")
-                        ListTileRow(text: events[i].title, icon: Icons.info),
+                        ListTileRow(
+                            text: events[i].title,
+                            icon: isXL ? Icons.terrain : Icons.info),
                     ],
                   ),
                 ),

--- a/fivekmrun_app_flutter/lib/home.dart
+++ b/fivekmrun_app_flutter/lib/home.dart
@@ -104,7 +104,7 @@ class _HomeState extends State<Home> with AfterLayoutMixin<Home> {
         Provider.of<AllFutureEventsResource>(context, listen: false).getAll(),
         "future events");
     reportOnFailure(
-        Provider.of<PastEventsResource>(context, listen: false).getAll(),
+        Provider.of<AllPastEventsResource>(context, listen: false).getAll(),
         "past events");
 
     this._tabHelper = TabNavigationHelper(this);

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -66,7 +66,7 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider(create: (_) => userRes),
         ChangeNotifierProvider(create: (_) => RunsResource()),
         ChangeNotifierProvider(create: (_) => AllFutureEventsResource()),
-        ChangeNotifierProvider(create: (_) => PastEventsResource()),
+        ChangeNotifierProvider(create: (_) => AllPastEventsResource()),
         ChangeNotifierProvider(create: (_) => OfflineChartResource()),
         ChangeNotifierProvider(create: (_) => LocalStorageResource()),
         ChangeNotifierProvider(create: (_) => StravaResource()),

--- a/fivekmrun_app_flutter/lib/state/event_model.dart
+++ b/fivekmrun_app_flutter/lib/state/event_model.dart
@@ -62,6 +62,17 @@ class Event {
     return groups.values.map((rows) => XLEvent.fromRows(rows)).toList();
   }
 
+  // Unlike the future-events list, past XLrun results must NOT be grouped —
+  // r_finish_pos is scoped to a single e_id, so short/medium/XL tiers at the
+  // same day/location are separate ranking pools and need their own
+  // tappable item, each leading to its own leaderboard. Each row becomes
+  // its own single-row XLEvent (reusing XLEvent.fromRows' existing handling
+  // of a one-row group) instead of being grouped by e_num/e_date.
+  static List<Event> listFromXLPastJson(dynamic json) {
+    List<dynamic> rows = json;
+    return rows.map((row) => XLEvent.fromRows([row])).toList();
+  }
+
   static List<Event> listFromKidsJson(dynamic json) {
     List<dynamic> events = json;
     List<Event> result = events.map((d) => Event.fromKidsJson(d)).toList();

--- a/fivekmrun_app_flutter/lib/state/events_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/events_resource.dart
@@ -195,7 +195,9 @@ class AllPastEventsResource extends ChangeNotifier {
     }
 
     this.loading = false;
-    this.value = combined..sortBy((e) => e.date);
+    // Past events read most-recent-first (unlike future events, which are
+    // soonest-first), so sort by date descending across both sources.
+    this.value = combined..sort((a, b) => b.date.compareTo(a.date));
 
     return this.value;
   }

--- a/fivekmrun_app_flutter/lib/state/events_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/events_resource.dart
@@ -89,6 +89,20 @@ class XLFutureEventsResource extends EventsResource {
   }
 }
 
+class XLPastEventsResource extends EventsResource {
+  XLPastEventsResource({super.client});
+
+  @override
+  String getEventUrl() {
+    return constants.xlPastEventsUrl;
+  }
+
+  @override
+  List<Event> listFromJsonParser(json) {
+    return Event.listFromXLPastJson(json);
+  }
+}
+
 class KidsFutureEventsResource extends EventsResource {
   KidsFutureEventsResource({super.client});
 
@@ -134,6 +148,46 @@ class AllFutureEventsResource extends ChangeNotifier {
       combined = List<Event>.from(futureEvents)
         ..addAll(xlFutureEvents)
         ..addAll(kidsFutureEvents);
+    } catch (_) {
+      // Keep whatever was already loaded rather than blanking the events tab.
+      this.loading = false;
+      rethrow;
+    }
+
+    this.loading = false;
+    this.value = combined..sortBy((e) => e.date);
+
+    return this.value;
+  }
+}
+
+class AllPastEventsResource extends ChangeNotifier {
+  /// Injectable for tests; forwarded to the composed per-type resources.
+  final http.Client? _client;
+
+  AllPastEventsResource({http.Client? client}) : _client = client;
+
+  // Not `late`: a failed fetch now leaves [value] untouched, so it has to be
+  // readable before the first successful load.
+  List<Event> value = <Event>[];
+
+  bool _loading = true;
+
+  bool get loading => _loading;
+  set loading(bool value) {
+    if (_loading != value) {
+      _loading = value;
+      notifyListeners();
+    }
+  }
+
+  Future<List<Event>> getAll() async {
+    final List<Event> combined;
+    try {
+      var pastEvents = await PastEventsResource(client: _client).getAll();
+      var xlPastEvents = await XLPastEventsResource(client: _client).getAll();
+
+      combined = List<Event>.from(pastEvents)..addAll(xlPastEvents);
     } catch (_) {
       // Keep whatever was already loaded rather than blanking the events tab.
       this.loading = false;

--- a/fivekmrun_app_flutter/lib/state/results_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/results_resource.dart
@@ -24,11 +24,11 @@ class ResultsResource extends ChangeNotifier {
     }
   }
 
-  Future<List<Result>> getAll(int eventId) async {
+  Future<List<Result>> getAll(int eventId, {String? baseUrl}) async {
     this.loading = true;
 
-    http.Response response = await _client
-        .get(Uri.parse("${constants.resultEventsUrl}${eventId.toString()}"));
+    http.Response response = await _client.get(Uri.parse(
+        "${baseUrl ?? constants.resultEventsUrl}${eventId.toString()}"));
     if (!isJsonResponse(
         response.statusCode, response.headers["content-type"])) {
       this.loading = false;

--- a/fivekmrun_app_flutter/test/events/past_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/past_events_test.dart
@@ -1,0 +1,55 @@
+import 'package:fivekmrun_flutter/events/future_events.dart' show XLBadge;
+import 'package:fivekmrun_flutter/events/past_events.dart';
+import 'package:fivekmrun_flutter/state/event_model.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+void main() {
+  testWidgets('regular past event has no XL badge', (tester) async {
+    final event = Event.fromJson({
+      "e_id": 1,
+      "e_title": "Race",
+      "e_date": 1609459200,
+      "e_time": "09:00",
+      "n_name": "Sofia",
+      "e_sponsor": "",
+    });
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: PastEventsList(events: [event])),
+        )));
+
+    expect(find.byType(XLBadge), findsNothing);
+    expect(find.text("Sofia"), findsOneWidget);
+  });
+
+  testWidgets(
+      'XLrun past results show the XL badge and real mileage, ungrouped',
+      (tester) async {
+    final events = Event.listFromXLPastJson([
+      {
+        "e_id": 393,
+        "n_name": "Сеславци 15.2 км",
+        "e_date": 1783803600,
+        "e_time": "10:00",
+      },
+      {
+        "e_id": 394,
+        "n_name": "Сеславци 7.6 км",
+        "e_date": 1783803600,
+        "e_time": "10:00",
+      },
+    ]);
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: PastEventsList(events: events)),
+        )));
+
+    // Same day/location, but rendered as two separate tappable items, each
+    // with its own badge and mileage — not merged into one grouped card.
+    expect(find.byType(XLBadge), findsNWidgets(2));
+    expect(find.text("15.2 km"), findsOneWidget);
+    expect(find.text("7.6 km"), findsOneWidget);
+  });
+}

--- a/fivekmrun_app_flutter/test/events/past_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/past_events_test.dart
@@ -1,4 +1,4 @@
-import 'package:fivekmrun_flutter/events/future_events.dart' show XLBadge;
+import 'package:fivekmrun_flutter/common/pill.dart';
 import 'package:fivekmrun_flutter/events/past_events.dart';
 import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:flutter/material.dart';
@@ -20,7 +20,7 @@ void main() {
           home: Scaffold(body: PastEventsList(events: [event])),
         )));
 
-    expect(find.byType(XLBadge), findsNothing);
+    expect(find.byType(XLPill), findsNothing);
     expect(find.text("Sofia"), findsOneWidget);
   });
 
@@ -48,7 +48,7 @@ void main() {
 
     // Same day/location, but rendered as two separate tappable items, each
     // with its own badge and mileage — not merged into one grouped card.
-    expect(find.byType(XLBadge), findsNWidgets(2));
+    expect(find.byType(XLPill), findsNWidgets(2));
     expect(find.text("15.2 km"), findsOneWidget);
     expect(find.text("7.6 km"), findsOneWidget);
   });

--- a/fivekmrun_app_flutter/test/state/event_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/event_model_test.dart
@@ -178,6 +178,49 @@ void main() {
     });
   });
 
+  group('Event.listFromXLPastJson', () {
+    test(
+        'does NOT group same-day/location rows — each distance tier is its '
+        'own separate item, unlike listFromXLJson', () {
+      final events = Event.listFromXLPastJson([
+        {
+          "e_id": 393,
+          "n_name": "Сеславци 15.2 км",
+          "e_num": 2,
+          "e_date": 1783803600,
+          "e_time": "10:00",
+        },
+        {
+          "e_id": 394,
+          "n_name": "Сеславци 7.6 км",
+          "e_num": 2,
+          "e_date": 1783803600,
+          "e_time": "10:00",
+        },
+      ]);
+
+      expect(events, hasLength(2));
+      expect(events.every((e) => e is XLEvent), isTrue);
+      expect(events.map((e) => e.id), [393, 394]);
+    });
+
+    test('parses the real mileage into each item\'s title/distances', () {
+      final events = Event.listFromXLPastJson([
+        {
+          "e_id": 393,
+          "n_name": "Сеславци 15.2 км",
+          "e_date": 1783803600,
+          "e_time": "10:00",
+        },
+      ]);
+
+      final e = events.single as XLEvent;
+      expect(e.distances, ["15.2 km"]);
+      expect(e.title, "15.2 km");
+      expect(e.location, "Сеславци");
+    });
+  });
+
   group('Event.fromKidsJson', () {
     test('uses e_title as title and n_name as location', () {
       final e = Event.fromKidsJson({

--- a/fivekmrun_app_flutter/test/state/events_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/events_resource_test.dart
@@ -119,5 +119,35 @@ void main() {
 
       await expectLater(resource.getAll(), throwsA(isA<FetchException>()));
     });
+
+    test('sorts the merged past events by date, most recent first', () async {
+      // The regular past event is OLDER (2020); the XL past event is NEWER
+      // (2023). Regardless of which source is appended first, the merged list
+      // must lead with the most recent event.
+      final client = MockClient((request) async {
+        final bool isXl = request.url.path.contains("xlrun");
+        return http.Response(
+            jsonEncode([
+              {
+                "e_id": isXl ? 394 : 1,
+                "e_title": isXl ? "" : "Old Race",
+                "e_date": isXl ? 1700000000 : 1600000000,
+                "e_time": "09:00",
+                "n_name": isXl ? "Сеславци 7.6 км" : "Sofia",
+                "e_sponsor": "",
+              }
+            ]),
+            200,
+            headers: _jsonHeaders);
+      });
+      final resource = AllPastEventsResource(client: client);
+
+      final events = await resource.getAll();
+
+      expect(events, hasLength(2));
+      expect(events.first.date.isAfter(events.last.date), isTrue,
+          reason: "past events should be ordered most-recent-first");
+      expect(events.first.date.millisecondsSinceEpoch, 1700000000 * 1000);
+    });
   });
 }

--- a/fivekmrun_app_flutter/test/state/events_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/events_resource_test.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:fivekmrun_flutter/state/event_model.dart';
 import 'package:fivekmrun_flutter/state/events_resource.dart';
 import 'package:fivekmrun_flutter/state/fetch_exception.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -63,6 +64,58 @@ void main() {
       final client = MockClient(
           (_) async => http.Response("nope", 500, headers: _jsonHeaders));
       final resource = AllFutureEventsResource(client: client);
+
+      await expectLater(resource.getAll(), throwsA(isA<FetchException>()));
+    });
+  });
+
+  group('XLPastEventsResource.getAll', () {
+    test('parses each row as its own ungrouped XLEvent', () async {
+      final client = MockClient((_) async => http.Response(
+          jsonEncode([
+            {
+              "e_id": 393,
+              "n_name": "Сеславци 15.2 км",
+              "e_date": 1783803600,
+              "e_time": "10:00",
+            },
+            {
+              "e_id": 394,
+              "n_name": "Сеславци 7.6 км",
+              "e_date": 1783803600,
+              "e_time": "10:00",
+            },
+          ]),
+          200,
+          headers: _jsonHeaders));
+      final resource = XLPastEventsResource(client: client);
+
+      final events = await resource.getAll();
+
+      // Same day/location, but NOT grouped — each distance tier is its own
+      // separate leaderboard, unlike the future-events grouping.
+      expect(events, hasLength(2));
+      expect(events.every((e) => e is XLEvent), isTrue);
+    });
+  });
+
+  group('AllPastEventsResource.getAll', () {
+    test('combines regular and XL past-event sources', () async {
+      final client = MockClient((_) async =>
+          http.Response(jsonEncode(_events()), 200, headers: _jsonHeaders));
+      final resource = AllPastEventsResource(client: client);
+
+      final events = await resource.getAll();
+
+      // One from PastEventsResource, one from XLPastEventsResource.
+      expect(events, hasLength(2));
+      expect(resource.loading, isFalse);
+    });
+
+    test('rethrows if any composed source fails', () async {
+      final client = MockClient(
+          (_) async => http.Response("nope", 500, headers: _jsonHeaders));
+      final resource = AllPastEventsResource(client: client);
 
       await expectLater(resource.getAll(), throwsA(isA<FetchException>()));
     });

--- a/fivekmrun_app_flutter/test/state/results_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/results_resource_test.dart
@@ -65,5 +65,21 @@ void main() {
 
       expect(await resource.getAll(99), isEmpty);
     });
+
+    test('hits the given baseUrl instead of the default when provided',
+        () async {
+      String? requestedUrl;
+      final client = MockClient((request) async {
+        requestedUrl = request.url.toString();
+        return http.Response(jsonEncode(_officialResults()), 200,
+            headers: _jsonHeaders);
+      });
+      final resource = ResultsResource(client: client);
+
+      await resource.getAll(393,
+          baseUrl: "https://5kmrun.bg/api/xlrun/result/");
+
+      expect(requestedUrl, "https://5kmrun.bg/api/xlrun/result/393");
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Adds past XLrun events into the results flow, following the existing `PastEventsResource` pattern. Unlike the future-events list (#176/#183), **results are NOT grouped** — `r_finish_pos` is scoped to a single event id, so short/medium/XL tiers at the same day/location are separate ranking pools and need their own tappable item, each leading to its own leaderboard.
- `Event.listFromXLPastJson` (new, `lib/state/event_model.dart`) maps each row from `xlrun/results` through the existing `XLEvent.fromRows([row])` single-row handling instead of grouping by `e_num`/`e_date` — reusing the location/distance-parsing logic already tested for the future-events list, just applied per-row instead of per-group.
- New `XLPastEventsResource` (`lib/state/events_resource.dart`) fetches `api/xlrun/results` (new `xlPastEventsUrl` constant). New `AllPastEventsResource` composes it with the existing `PastEventsResource`, mirroring how `AllFutureEventsResource` already composes the future-event sources. Wired in everywhere `PastEventsResource` was previously provided/consumed directly: `main.dart`, `home.dart`, `common/refresh_helper.dart`, `events/events_page.dart`.
- `lib/events/past_events.dart` shows the existing blue "XL" badge (reused from `future_events.dart`) and each item's real parsed mileage (e.g. "18.0 km"), so tiers are distinguishable at a glance — same visual language as the future-events XL cards.
- `lib/events/event_results_page.dart` routes to `xlrun/result/<eventId>` instead of `5kmrun/result/<eventId>` for XL items, via a new optional `baseUrl` param on `ResultsResource.getAll` (new `xlResultEventsUrl` constant). `Result.fromEventJson`/`listFromEventJson` needed no changes — the XL payload's `r_*`/`u_*`/`e_*` keys are identical in shape to the regular endpoint, confirmed both by the issue and by live verification below.

## Likely files touched (as scoped in the issue)
- `lib/state/events_resource.dart` — new `XLPastEventsResource` + `AllPastEventsResource`.
- `lib/state/event_model.dart` — new `Event.listFromXLPastJson`.
- `lib/events/past_events.dart`, `lib/events/event_results_page.dart` — badge/mileage rendering, routing to the XL result endpoint.
- `lib/constants.dart`, `lib/main.dart`, `lib/home.dart`, `lib/common/refresh_helper.dart`, `lib/events/events_page.dart` — wiring the new composed resource in place of the old single-source one.

## Test plan
- [x] `flutter analyze` on changed files — no new issues beyond 4 pre-existing-style `unnecessary_this` infos in `events_resource.dart` (matching that file's existing convention throughout); verified by diffing analyzer output before/after.
- [x] `flutter test` — full suite passes, including new/updated tests:
  - `test/state/event_model_test.dart` — `Event.listFromXLPastJson` keeps same-day/location rows as separate items (not grouped like `listFromXLJson`), and parses real mileage into each item's title/distances/location.
  - `test/state/events_resource_test.dart` — `XLPastEventsResource` parses each row as its own ungrouped `XLEvent`; `AllPastEventsResource` combines both past-event sources and rethrows if either fails.
  - `test/state/results_resource_test.dart` — `ResultsResource.getAll` hits the given `baseUrl` instead of the default when provided.
  - `test/events/past_events_test.dart` (new) — a regular past event has no XL badge; XLrun past results show the XL badge and real mileage as separate ungrouped items.
- [x] **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app against the live production API, logged in as an existing user, switched to "Минали събития" (past events).
  - Confirmed real live XL past-event cards with the blue "XL" badge and correct parsed mileage (e.g. "18.0 km", "5.5 km", "16.5 km", "11.0 km") — including three separate cards for the same "Бистрица" day/location at different distances, exactly the ungrouped-per-tier behavior the issue asks for.
  - Tapped the 18.0 km Западен парк item and the 5.5 km Бистрица item — each opened its own distinct leaderboard from `xlrun/result/<eventId>` with genuinely different runners/times (~1h09m winning time for the 18km tier vs. ~23min for the 5.5km tier), confirming the per-distance routing hits the correct XL event id rather than falling back to the regular 5km endpoint.
- **iOS Simulator:** not run this pass — same one-time interactive `xcode-select` prompt limitation noted in prior PRs, not available in this automated environment.

Closes #177