### PR TITLE
KidsRun: add past results/leaderboards

### DIFF
--- a/fivekmrun_app_flutter/lib/constants.dart
+++ b/fivekmrun_app_flutter/lib/constants.dart
@@ -5,6 +5,8 @@ const xlFutureEventsUrl = "https://5kmrun.bg/api/xlrun/events";
 const xlPastEventsUrl = "https://5kmrun.bg/api/xlrun/results";
 const xlResultEventsUrl = "https://5kmrun.bg/api/xlrun/result/";
 const kidsFutureEventsUrl = "https://5kmrun.bg/api/kidsrun/events";
+const kidsPastEventsUrl = "https://5kmrun.bg/api/kidsrun/results";
+const kidsResultEventsUrl = "https://5kmrun.bg/api/kidsrun/result/";
 const wrapUrl = "https://wrapped.5kmrun.bg/";
 
 const endpointBaseUrl = "https://5kmrun.bg/api/5kmrun/";

--- a/fivekmrun_app_flutter/lib/events/event_results_page.dart
+++ b/fivekmrun_app_flutter/lib/events/event_results_page.dart
@@ -19,12 +19,18 @@ class _EventResultsPageState extends State<EventResultsPage> {
   Widget build(BuildContext context) {
     Event event = ModalRoute.of(context)?.settings.arguments as Event;
     final bool isXL = event is XLEvent;
+    final bool isKids = event is KidsEvent;
+
+    final String? baseUrl = isXL
+        ? constants.xlResultEventsUrl
+        : isKids
+            ? constants.kidsResultEventsUrl
+            : null;
 
     return Scaffold(
       appBar: AppBar(title: Text("Резултати")),
       body: FutureBuilder<List<Result>>(
-        future: results.getAll(event.id,
-            baseUrl: isXL ? constants.xlResultEventsUrl : null),
+        future: results.getAll(event.id, baseUrl: baseUrl),
         initialData: [],
         builder: (BuildContext context, AsyncSnapshot<List<Result>> snapshot) {
           switch (snapshot.connectionState) {

--- a/fivekmrun_app_flutter/lib/events/past_events.dart
+++ b/fivekmrun_app_flutter/lib/events/past_events.dart
@@ -23,6 +23,7 @@ class PastEventsList extends StatelessWidget {
       itemBuilder: (BuildContext context, int i) {
         final Event event = events[i];
         final bool isXL = event is XLEvent;
+        final bool isKids = event is KidsEvent;
 
         return Card(
           child: ListTile(
@@ -41,6 +42,11 @@ class PastEventsList extends StatelessWidget {
                           padding: EdgeInsets.only(bottom: 4),
                           child: XLPill(),
                         ),
+                      if (isKids)
+                        const Padding(
+                          padding: EdgeInsets.only(bottom: 4),
+                          child: KidsPill(),
+                        ),
                       ListTileRow(
                           text: events[i].location, icon: Icons.pin_drop),
                       ListTileRow(
@@ -49,7 +55,11 @@ class PastEventsList extends StatelessWidget {
                       if (events[i].title != "")
                         ListTileRow(
                             text: events[i].title,
-                            icon: isXL ? Icons.terrain : Icons.info),
+                            icon: isXL
+                                ? Icons.terrain
+                                : isKids
+                                    ? Icons.child_care
+                                    : Icons.info),
                     ],
                   ),
                 ),

--- a/fivekmrun_app_flutter/lib/state/events_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/events_resource.dart
@@ -117,6 +117,20 @@ class KidsFutureEventsResource extends EventsResource {
   }
 }
 
+class KidsPastEventsResource extends EventsResource {
+  KidsPastEventsResource({super.client});
+
+  @override
+  String getEventUrl() {
+    return constants.kidsPastEventsUrl;
+  }
+
+  @override
+  List<Event> listFromJsonParser(json) {
+    return Event.listFromKidsJson(json);
+  }
+}
+
 class AllFutureEventsResource extends ChangeNotifier {
   /// Injectable for tests; forwarded to the composed per-type resources.
   final http.Client? _client;
@@ -186,8 +200,12 @@ class AllPastEventsResource extends ChangeNotifier {
     try {
       var pastEvents = await PastEventsResource(client: _client).getAll();
       var xlPastEvents = await XLPastEventsResource(client: _client).getAll();
+      var kidsPastEvents =
+          await KidsPastEventsResource(client: _client).getAll();
 
-      combined = List<Event>.from(pastEvents)..addAll(xlPastEvents);
+      combined = List<Event>.from(pastEvents)
+        ..addAll(xlPastEvents)
+        ..addAll(kidsPastEvents);
     } catch (_) {
       // Keep whatever was already loaded rather than blanking the events tab.
       this.loading = false;
@@ -196,7 +214,7 @@ class AllPastEventsResource extends ChangeNotifier {
 
     this.loading = false;
     // Past events read most-recent-first (unlike future events, which are
-    // soonest-first), so sort by date descending across both sources.
+    // soonest-first), so sort by date descending across all sources.
     this.value = combined..sort((a, b) => b.date.compareTo(a.date));
 
     return this.value;

--- a/fivekmrun_app_flutter/test/events/past_events_test.dart
+++ b/fivekmrun_app_flutter/test/events/past_events_test.dart
@@ -21,6 +21,7 @@ void main() {
         )));
 
     expect(find.byType(XLPill), findsNothing);
+    expect(find.byType(KidsPill), findsNothing);
     expect(find.text("Sofia"), findsOneWidget);
   });
 
@@ -51,5 +52,26 @@ void main() {
     expect(find.byType(XLPill), findsNWidgets(2));
     expect(find.text("15.2 km"), findsOneWidget);
     expect(find.text("7.6 km"), findsOneWidget);
+  });
+
+  testWidgets('KidsRun past results show the Kids badge', (tester) async {
+    final events = Event.listFromKidsJson([
+      {
+        "e_id": 519,
+        "n_name": "Южен Парк Kids",
+        "e_date": 1784322000,
+        "e_time": "10:00",
+        "e_title": "Детско бягане 2 км",
+      },
+    ]);
+
+    await mockNetworkImagesFor(() => tester.pumpWidget(MaterialApp(
+          home: Scaffold(body: PastEventsList(events: events)),
+        )));
+
+    expect(find.byType(KidsPill), findsOneWidget);
+    expect(find.byType(XLPill), findsNothing);
+    expect(find.text("Южен Парк Kids"), findsOneWidget);
+    expect(find.text("Детско бягане 2 км"), findsOneWidget);
   });
 }

--- a/fivekmrun_app_flutter/test/state/events_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/events_resource_test.dart
@@ -99,16 +99,42 @@ void main() {
     });
   });
 
+  group('KidsPastEventsResource.getAll', () {
+    test('parses each row as its own KidsEvent (single-distance, no grouping)',
+        () async {
+      final client = MockClient((_) async => http.Response(
+          jsonEncode([
+            {
+              "e_id": 519,
+              "n_name": "Южен Парк Kids",
+              "e_date": 1784322000,
+              "e_time": "10:00",
+              "e_title": "Детско бягане 2 км",
+            },
+          ]),
+          200,
+          headers: _jsonHeaders));
+      final resource = KidsPastEventsResource(client: client);
+
+      final events = await resource.getAll();
+
+      expect(events, hasLength(1));
+      expect(events.single, isA<KidsEvent>());
+      expect(events.single.title, "Детско бягане 2 км");
+    });
+  });
+
   group('AllPastEventsResource.getAll', () {
-    test('combines regular and XL past-event sources', () async {
+    test('combines regular, XL and Kids past-event sources', () async {
       final client = MockClient((_) async =>
           http.Response(jsonEncode(_events()), 200, headers: _jsonHeaders));
       final resource = AllPastEventsResource(client: client);
 
       final events = await resource.getAll();
 
-      // One from PastEventsResource, one from XLPastEventsResource.
-      expect(events, hasLength(2));
+      // One from each of PastEventsResource, XLPastEventsResource and
+      // KidsPastEventsResource.
+      expect(events, hasLength(3));
       expect(resource.loading, isFalse);
     });
 
@@ -121,19 +147,24 @@ void main() {
     });
 
     test('sorts the merged past events by date, most recent first', () async {
-      // The regular past event is OLDER (2020); the XL past event is NEWER
-      // (2023). Regardless of which source is appended first, the merged list
-      // must lead with the most recent event.
+      // Distinct dates per source: XL newest (2023), Kids middle (2022),
+      // regular oldest (2020). Regardless of the order the sources are
+      // appended, the merged list must run strictly most-recent-first.
       final client = MockClient((request) async {
-        final bool isXl = request.url.path.contains("xlrun");
+        final String path = request.url.path;
+        final int date = path.contains("xlrun")
+            ? 1700000000 // 2023
+            : path.contains("kidsrun")
+                ? 1650000000 // 2022
+                : 1600000000; // 2020
         return http.Response(
             jsonEncode([
               {
-                "e_id": isXl ? 394 : 1,
-                "e_title": isXl ? "" : "Old Race",
-                "e_date": isXl ? 1700000000 : 1600000000,
+                "e_id": 1,
+                "e_title": "Race",
+                "e_date": date,
                 "e_time": "09:00",
-                "n_name": isXl ? "Сеславци 7.6 км" : "Sofia",
+                "n_name": "Sofia",
                 "e_sponsor": "",
               }
             ]),
@@ -144,10 +175,11 @@ void main() {
 
       final events = await resource.getAll();
 
-      expect(events, hasLength(2));
-      expect(events.first.date.isAfter(events.last.date), isTrue,
+      expect(events, hasLength(3));
+      final dates =
+          events.map((e) => e.date.millisecondsSinceEpoch ~/ 1000).toList();
+      expect(dates, [1700000000, 1650000000, 1600000000],
           reason: "past events should be ordered most-recent-first");
-      expect(events.first.date.millisecondsSinceEpoch, 1700000000 * 1000);
     });
   });
 }


### PR DESCRIPTION
## Summary
- Adds past KidsRun events into the results flow, mirroring the XLrun past-results work in #194. KidsRun events are single-distance (#185), so unlike XL there's **no per-tier grouping concern** — each event is already its own item.
- New `KidsPastEventsResource` (`lib/state/events_resource.dart`) fetches `api/kidsrun/results` (new `kidsPastEventsUrl` constant), composed into `AllPastEventsResource` alongside the regular and XL past-event sources.
- Reuses `Event.listFromKidsJson` as-is for the past-events endpoint — the payload shape is the same as the future-events one this parser already handles (`e_id, n_name, e_date, e_time, e_title`), so no new parser was needed, unlike XL's ungrouping logic.
- `lib/events/past_events.dart` shows the green "Kids" badge (reused from `future_events.dart`, introduced in #185) and a child-care icon, so Kids items are visually distinguishable from regular and XL past events.
- `lib/events/event_results_page.dart` routes to `kidsrun/result/<eventId>` (new `kidsResultEventsUrl` constant) instead of the regular endpoint for Kids items, via the `baseUrl` param on `ResultsResource.getAll` added in #194.

## Scope decisions from the issue
- **`_k`-suffixed fields (`u_age_percent_k`, `u_best_time_k`):** `Result.fromEventJson` doesn't read `u_age_percent`/`u_best_time` at all today (confirmed by reading `result_model.dart`), so these `_k`-suffixed variants are simply never touched — no parsing risk, no code changes needed.
- **School (`s_id`/`s_name`):** left unsurfaced on the leaderboard for now, per the issue's "decide whether to show" — the existing `Result`/`ResultsList` has no school field or slot today, and adding one is a bigger UI decision than this issue's core ask (getting Kids results into the flow at all).

## ⚠️ Branch dependency
This branch merges both **#191** (introduces the `KidsEvent` type / Kids badge this PR reuses) and **#194** (introduces `AllPastEventsResource` and the whole past-events-composition + `baseUrl` infrastructure this PR reuses for Kids). Neither is merged yet, so this diff currently includes their commits too — recommend merging #191 and #194 first, then this one (it should then fast-forward to just the Kids-specific commit), or rebasing this branch once they land.

## Test plan
- [x] `flutter analyze` on changed files — no new issues (diffed analyzer output before/after; identical).
- [x] `flutter test` — full suite passes, including new/updated tests:
  - `test/state/events_resource_test.dart` — `KidsPastEventsResource` parses each row as its own `KidsEvent`; `AllPastEventsResource` now combines all three past-event sources (regular, XL, Kids).
  - `test/events/past_events_test.dart` — KidsRun past results show the Kids badge (and not the XL badge); regular events show neither.
- [x] **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app against the live production API, logged in as an existing user, switched to "Минали събития" (past events).
  - Confirmed a real live Kids past event ("Южен Парк Kids", 07.03.2026, "Детско бягане 2 км") renders with the green "Kids" badge, interleaved chronologically with XL and regular past events.
  - Tapped it — opened a genuine Kids-specific leaderboard from `kidsrun/result/<eventId>` with realistic 2km finish times (07:39–09:11) and a runner labeled "(Junior)", clearly distinct from both the 5km and XL leaderboards seen in the same session — confirming the routing hits the correct endpoint.
- **iOS Simulator:** not run this pass — same one-time interactive `xcode-select` prompt limitation noted in prior PRs, not available in this automated environment.

Closes #186