### PR TITLE
KidsRun: add engagement stats card to the profile page

### DIFF
--- a/fivekmrun_app_flutter/lib/constants.dart
+++ b/fivekmrun_app_flutter/lib/constants.dart
@@ -10,6 +10,7 @@ const userEndpointUrl = "https://5kmrun.bg/api/selfie/user/";
 const runsEndpointUrl = endpointBaseUrl + "user/";
 const offlineChartEndpointUrl = "https://5kmrun.bg/api/selfie/ofc/";
 const xlUserEndpointUrl = "https://5kmrun.bg/api/xlrun/user/";
+const kidsUserEndpointUrl = "https://5kmrun.bg/api/kidsrun/user/";
 
 const String key_userId = "5kmrun_UserID";
 const String key_token = "5kmrun_Token";

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -10,6 +10,7 @@ import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/run_card.dart';
 import 'package:fivekmrun_flutter/constants.dart';
 import 'package:fivekmrun_flutter/custom_icons.dart';
+import 'package:fivekmrun_flutter/state/kids_stats.dart';
 import 'package:fivekmrun_flutter/state/run_model.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
@@ -39,6 +40,7 @@ class ProfileDashboard extends StatelessWidget {
         runs.where((r) => r.runType == RunType.official).length > 0;
     final hasSelfieRuns = runs != null &&
         runs.where((r) => r.runType == RunType.selfie).length > 0;
+    final kidsStats = KidsStats.fromRuns(runs ?? <Run>[]);
 
     final goToSettings = () {
       Navigator.of(context, rootNavigator: true).pushNamed("settings");
@@ -184,6 +186,7 @@ class ProfileDashboard extends StatelessWidget {
                 if (hasSelfieRuns)
                   this.buildRunsCards(
                       runsRes.bestSelfieRun!, runsRes.lastSelfieRun!, "selfie"),
+                if (kidsStats != null) this.buildKidsStatsCard(kidsStats),
                 if (hasAnyRuns) this.buildRunsChartCard(runs),
                 if (!runsRes.loading && !hasAnyRuns)
                   Row(
@@ -221,6 +224,59 @@ class ProfileDashboard extends StatelessWidget {
           ),
         ),
       ],
+    );
+  }
+
+  Widget buildKidsStatsCard(KidsStats stats) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Builder(builder: (context) {
+          final theme = Theme.of(context);
+          final labelStyle = theme.textTheme.bodyMedium;
+          final valueStyle = theme.textTheme.titleLarge
+              ?.copyWith(color: theme.colorScheme.secondary);
+
+          Widget stat(String value, String label) {
+            return Column(
+              children: <Widget>[
+                Text(value, style: valueStyle),
+                Text(label, style: labelStyle, textAlign: TextAlign.center),
+              ],
+            );
+          }
+
+          final km = (stats.totalDistanceMeters / 1000).toStringAsFixed(1);
+
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: <Widget>[
+              Text("KidsRun", style: theme.textTheme.titleSmall),
+              const SizedBox(height: 8),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: <Widget>[
+                  stat(stats.runsThisYear.toString(), "тази година"),
+                  stat(stats.runsAllTime.toString(), "общо"),
+                  stat(km, "км общо"),
+                  if (stats.bestRun?.time != null)
+                    stat(stats.bestRun!.time!, "най-добро"),
+                ],
+              ),
+              if (stats.mostRecentRun != null)
+                Padding(
+                  padding: const EdgeInsets.only(top: 8.0),
+                  child: Text(
+                    (stats.mostRecentRun!.location ?? "").isNotEmpty
+                        ? "Последно: ${stats.mostRecentRun!.displayDate} · ${stats.mostRecentRun!.location}"
+                        : "Последно: ${stats.mostRecentRun!.displayDate}",
+                    style: labelStyle,
+                  ),
+                ),
+            ],
+          );
+        }),
+      ),
     );
   }
 

--- a/fivekmrun_app_flutter/lib/runs/user_runs_page.dart
+++ b/fivekmrun_app_flutter/lib/runs/user_runs_page.dart
@@ -58,7 +58,9 @@ class UserRunsList extends StatelessWidget {
                   ListTileRow(
                     icon: run.runType == RunType.xl
                         ? Icons.terrain
-                        : Icons.pin_drop,
+                        : run.runType == RunType.kids
+                            ? Icons.child_care
+                            : Icons.pin_drop,
                     text: run.location!,
                   ),
                 ListTileRow(
@@ -107,6 +109,13 @@ class RunTypePill extends StatelessWidget {
         backgroundColor = Colors.blue;
         textColor = Colors.white;
         label = "XL";
+        break;
+      case RunType.kids:
+        // Same green used by the Kids badge on the future-events cards
+        // (#185/#186), for a consistent Kids visual language across the app.
+        backgroundColor = Colors.green;
+        textColor = Colors.white;
+        label = "Kids";
         break;
     }
 

--- a/fivekmrun_app_flutter/lib/state/kids_stats.dart
+++ b/fivekmrun_app_flutter/lib/state/kids_stats.dart
@@ -1,0 +1,58 @@
+import 'package:fivekmrun_flutter/state/run_model.dart';
+
+/// Aggregate KidsRun engagement stats for the profile page, derived from the
+/// user's already-fetched runs list (RunsResource) rather than a second
+/// fetch against kidsrun/user/<id> — RunsResource already hits that endpoint
+/// to build "Твоите бягания" (#188), so calling it again here would just
+/// duplicate the same request for data already in memory. Mirrors XLStats
+/// (#178), with one difference: KidsRun events are all a fixed ~2km
+/// (Run.kidsDistanceMeters), so unlike XL, total distance and a single
+/// "best time" are both directly comparable across every Kids run and are
+/// included here.
+class KidsStats {
+  final int runsThisYear;
+  final int runsAllTime;
+  final int totalDistanceMeters;
+  final Run? mostRecentRun;
+  final Run? bestRun;
+
+  const KidsStats({
+    required this.runsThisYear,
+    required this.runsAllTime,
+    required this.totalDistanceMeters,
+    required this.mostRecentRun,
+    required this.bestRun,
+  });
+
+  /// Returns null if the user has no Kids history, so callers can skip
+  /// rendering the stat card entirely rather than showing all-zero stats.
+  static KidsStats? fromRuns(List<Run> allRuns) {
+    final kidsRuns = allRuns.where((r) => r.runType == RunType.kids).toList();
+    if (kidsRuns.isEmpty) {
+      return null;
+    }
+
+    kidsRuns.sort(
+        (a, b) => (b.date ?? DateTime(0)).compareTo(a.date ?? DateTime(0)));
+
+    final currentYear = DateTime.now().year;
+    final runsThisYear =
+        kidsRuns.where((r) => r.date?.year == currentYear).length;
+
+    // Every Kids run is the same fixed distance, so this is a plain sum —
+    // no unparseable-name caveat like XL's per-run distance parsing.
+    final totalDistanceMeters =
+        kidsRuns.fold<int>(0, (sum, r) => sum + (r.distance ?? 0));
+
+    final Run bestRun = kidsRuns.reduce((a, b) =>
+        (a.timeInSeconds ?? 1 << 30) < (b.timeInSeconds ?? 1 << 30) ? a : b);
+
+    return KidsStats(
+      runsThisYear: runsThisYear,
+      runsAllTime: kidsRuns.length,
+      totalDistanceMeters: totalDistanceMeters,
+      mostRecentRun: kidsRuns.first,
+      bestRun: bestRun,
+    );
+  }
+}

--- a/fivekmrun_app_flutter/lib/state/run_model.dart
+++ b/fivekmrun_app_flutter/lib/state/run_model.dart
@@ -8,7 +8,7 @@ final DateFormat dateFromat = DateFormat(Constants.DATE_FORMAT);
 /// meant every consumer had to remember to exclude XL wherever it filtered
 /// on "not selfie" to mean "official". An enum makes the exclusivity
 /// structural instead of a convention every call site has to uphold.
-enum RunType { official, selfie, xl }
+enum RunType { official, selfie, xl, kids }
 
 class Run {
   final int id;
@@ -89,6 +89,31 @@ class Run {
         runType = RunType.xl,
         distance = _xlDistanceMetersFromName(json["n_name"]);
 
+  // KidsRun events are single-distance (~2 km, see #185) — unlike XLrun,
+  // n_name is already a clean location with no distance suffix to strip, so
+  // this is simpler than Run.fromXLJson: no name parsing, just a fixed
+  // distance for pace/speed.
+  static const int kidsDistanceMeters = 2000;
+
+  Run.fromKidsJson(dynamic json)
+      : id = json["r_id"],
+        eventId = json["r_eventid"],
+        date = DateTime.fromMillisecondsSinceEpoch(json["e_date"] * 1000),
+        time = timeInSecondsToString(json["r_time"]),
+        totalTime = timeInSecondsToString(json["r_time"]),
+        timeInSeconds = json["r_time"],
+        location = json["n_name"],
+        differenceFromBest = null,
+        differenceFromPrevious = null,
+        position = json["r_finish_pos"],
+        speed = timeInSecondsToSpeed(json["r_time"],
+            distanceMeters: kidsDistanceMeters),
+        notes = "",
+        pace = timeInSecondsToPace(json["r_time"],
+            distanceMeters: kidsDistanceMeters),
+        runType = RunType.kids,
+        distance = kidsDistanceMeters;
+
   static List<Run> listFromJson(Map<String, dynamic> json) {
     List<dynamic> runs = json["runners"];
     var result = List<Run>.from(runs.map((d) => Run.fromJson(d)));
@@ -137,6 +162,24 @@ class Run {
     }
 
     return byId.values.map((d) => Run.fromXLJson(d)).toList();
+  }
+
+  /// Same shape and same "runners" + "years"[].results duplication concern
+  /// as the XLrun user endpoint (see [listFromXLUserJson]) — merge and
+  /// de-dupe by r_id rather than picking just one source.
+  static List<Run> listFromKidsUserJson(dynamic json) {
+    final List<dynamic> current = (json["runners"] as List<dynamic>?) ?? [];
+    final List<dynamic> years = (json["years"] as List<dynamic>?) ?? [];
+    final List<dynamic> historic = years
+        .expand((y) => (y["results"] as List<dynamic>?) ?? const [])
+        .toList();
+
+    final Map<int, dynamic> byId = {};
+    for (final r in [...current, ...historic]) {
+      byId[r["r_id"] as int] = r;
+    }
+
+    return byId.values.map((d) => Run.fromKidsJson(d)).toList();
   }
 
   static final RegExp _xlNameDistancePattern =

--- a/fivekmrun_app_flutter/lib/state/runs_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/runs_resource.dart
@@ -69,6 +69,8 @@ class RunsResource extends ChangeNotifier {
       runs.addAll(selfieRuns.where((r) => r.timeInSeconds != null));
       final List<Run> xlRuns = await this.retrieveXLRuns(userId);
       runs.addAll(xlRuns.where((r) => r.timeInSeconds != null));
+      final List<Run> kidsRuns = await this.retrieveKidsRuns(userId);
+      runs.addAll(kidsRuns.where((r) => r.timeInSeconds != null));
     } catch (_) {
       this.loading = false;
       rethrow;
@@ -114,6 +116,20 @@ class RunsResource extends ChangeNotifier {
 
     String body = utf8.decode(response.bodyBytes);
     return Run.listFromXLUserJson(jsonDecode(body));
+  }
+
+  /// Same "non-JSON error page means no history" behavior as
+  /// [retrieveXLRuns] — most users have no Kids history.
+  Future<List<Run>> retrieveKidsRuns(int? userId) async {
+    final http.Response response = await _client
+        .get(Uri.parse("${constants.kidsUserEndpointUrl}$userId"));
+
+    if (!isJsonResponse(response.statusCode, response.headers["content-type"])) {
+      return <Run>[];
+    }
+
+    String body = utf8.decode(response.bodyBytes);
+    return Run.listFromKidsUserJson(jsonDecode(body));
   }
 
   void _processRuns(List<Run> runs) {

--- a/fivekmrun_app_flutter/test/state/kids_stats_test.dart
+++ b/fivekmrun_app_flutter/test/state/kids_stats_test.dart
@@ -1,0 +1,106 @@
+import 'package:fivekmrun_flutter/state/kids_stats.dart';
+import 'package:fivekmrun_flutter/state/run_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('KidsStats.fromRuns', () {
+    dynamic kidsJson({
+      required int rId,
+      required String nName,
+      required int eDate,
+      int rTime = 700,
+    }) {
+      return {
+        "r_id": rId,
+        "r_uid": 1,
+        "r_eventid": 1,
+        "r_finish_pos": 1,
+        "r_time": rTime,
+        "n_name": nName,
+        "e_date": eDate,
+      };
+    }
+
+    test('returns null when the user has no Kids runs', () {
+      final runs = [
+        Run.fromJson({
+          "r_id": 1,
+          "r_eventid": 1,
+          "e_date": 1609459200,
+          "r_time": 1500,
+          "n_name": "Sofia",
+          "r_finish_pos": 1,
+        }),
+      ];
+
+      expect(KidsStats.fromRuns(runs), isNull);
+    });
+
+    test('counts all-time and this-year runs, ignoring non-Kids runs', () {
+      final now = DateTime.now();
+      final thisYearEpoch =
+          DateTime(now.year, 6, 1).millisecondsSinceEpoch ~/ 1000;
+
+      final runs = [
+        Run.fromJson({
+          "r_id": 1,
+          "r_eventid": 1,
+          "e_date": 1609459200,
+          "r_time": 1500,
+          "n_name": "Sofia",
+          "r_finish_pos": 1,
+        }),
+        Run.fromKidsJson(
+            kidsJson(rId: 2, nName: "Южен Парк Kids", eDate: thisYearEpoch)),
+        Run.fromKidsJson(
+            kidsJson(rId: 3, nName: "Морска градина Варна", eDate: 1600000000)),
+      ];
+
+      final stats = KidsStats.fromRuns(runs)!;
+
+      expect(stats.runsAllTime, 2);
+      expect(stats.runsThisYear, 1);
+    });
+
+    test('sums the fixed per-run distance, unlike XL\'s parsed distance', () {
+      final runs = [
+        Run.fromKidsJson(
+            kidsJson(rId: 1, nName: "Южен Парк Kids", eDate: 1700000000)),
+        Run.fromKidsJson(kidsJson(
+            rId: 2, nName: "Морска градина Варна", eDate: 1700000001)),
+      ];
+
+      final stats = KidsStats.fromRuns(runs)!;
+
+      expect(stats.totalDistanceMeters, 2 * Run.kidsDistanceMeters);
+    });
+
+    test('best run is the fastest by time, meaningful since every Kids run '
+        'is the same fixed distance', () {
+      final runs = [
+        Run.fromKidsJson(kidsJson(
+            rId: 1, nName: "Slower", eDate: 1700000000, rTime: 800)),
+        Run.fromKidsJson(kidsJson(
+            rId: 2, nName: "Faster", eDate: 1700000001, rTime: 650)),
+      ];
+
+      final stats = KidsStats.fromRuns(runs)!;
+
+      expect(stats.bestRun!.location, "Faster");
+      expect(stats.bestRun!.timeInSeconds, 650);
+    });
+
+    test('most recent run is the latest by date, not by insertion order', () {
+      final runs = [
+        Run.fromKidsJson(
+            kidsJson(rId: 1, nName: "Older", eDate: 1600000000)),
+        Run.fromKidsJson(
+            kidsJson(rId: 2, nName: "Newer", eDate: 1700000000)),
+      ];
+
+      final stats = KidsStats.fromRuns(runs)!;
+
+      expect(stats.mostRecentRun!.location, "Newer");
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/run_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/run_model_test.dart
@@ -204,6 +204,90 @@ void main() {
     });
   });
 
+  group('Run.fromKidsJson', () {
+    dynamic kidsResultJson({
+      String nName = "Южен Парк Kids",
+      int rTime = 720,
+    }) {
+      return {
+        "r_id": 5001,
+        "r_uid": 13731,
+        "r_eventid": 519,
+        "r_finish_pos": 12,
+        "r_time": rTime,
+        "n_name": nName,
+        "e_date": 1784322000,
+      };
+    }
+
+    test('uses "n_name" directly as the location (no distance to strip)', () {
+      final run = Run.fromKidsJson(kidsResultJson(nName: "Южен Парк Kids"));
+      expect(run.location, "Южен Парк Kids");
+    });
+
+    test('marks the run as kids with a fixed 2km distance', () {
+      final run = Run.fromKidsJson(kidsResultJson());
+      expect(run.runType, RunType.kids);
+      expect(run.distance, 2000);
+    });
+
+    test('computes pace/speed off the fixed 2km distance', () {
+      final run = Run.fromKidsJson(kidsResultJson(rTime: 600));
+      expect(run.pace, Run.timeInSecondsToPace(600, distanceMeters: 2000));
+      expect(run.speed, Run.timeInSecondsToSpeed(600, distanceMeters: 2000));
+    });
+  });
+
+  group('Run.listFromKidsUserJson', () {
+    test('merges "runners" and "years[].results", de-duplicated by r_id', () {
+      final json = {
+        "runners": [
+          {
+            "r_id": 1,
+            "r_eventid": 519,
+            "r_time": 700,
+            "r_finish_pos": 1,
+            "n_name": "Южен Парк Kids",
+            "e_date": 1784322000,
+          }
+        ],
+        "years": [
+          {
+            "yr": "2026",
+            "results": [
+              {
+                "r_id": 1, // duplicate of the "runners" entry above
+                "r_eventid": 519,
+                "r_time": 700,
+                "r_finish_pos": 1,
+                "n_name": "Южен Парк Kids",
+                "e_date": 1784322000,
+              },
+              {
+                "r_id": 2,
+                "r_eventid": 520,
+                "r_time": 650,
+                "r_finish_pos": 3,
+                "n_name": "Морска градина Варна",
+                "e_date": 1700000000,
+              },
+            ],
+          }
+        ],
+      };
+
+      final runs = Run.listFromKidsUserJson(json);
+
+      expect(runs.length, 2);
+      expect(runs.map((r) => r.id).toSet(), {1, 2});
+      expect(runs.every((r) => r.runType == RunType.kids), isTrue);
+    });
+
+    test('handles missing "runners"/"years" gracefully', () {
+      expect(Run.listFromKidsUserJson({}), isEmpty);
+    });
+  });
+
   group('Run.timeInSecondsToString', () {
     test('zero-pads minutes and seconds', () {
       expect(Run.timeInSecondsToString(0), "00:00");

--- a/fivekmrun_app_flutter/test/state/runs_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/runs_resource_test.dart
@@ -46,13 +46,29 @@ final _xl = {
   ]
 };
 
-/// Routes the three endpoints [getByUserId] hits to the right payload.
+final _kids = {
+  "runners": [
+    {
+      "r_id": 4,
+      "r_eventid": 519,
+      "e_date": 1784322000,
+      "r_time": 700,
+      "n_name": "Южен Парк Kids",
+      "r_finish_pos": 1,
+    }
+  ]
+};
+
+/// Routes the four endpoints [getByUserId] hits to the right payload.
 ///
-/// XL defaults to the same non-JSON "no history" response the real endpoint
-/// gives most users (see [RunsResource.retrieveXLRuns]) so existing
-/// official/selfie-only assertions don't need to account for an XL run
-/// they didn't ask for.
-MockClient _client({int selfieStatus = 200, http.Response? xlResponse}) =>
+/// XL and Kids default to the same non-JSON "no history" response the real
+/// endpoints give most users (see [RunsResource.retrieveXLRuns]/
+/// [RunsResource.retrieveKidsRuns]) so existing official/selfie-only
+/// assertions don't need to account for runs they didn't ask for.
+MockClient _client(
+        {int selfieStatus = 200,
+        http.Response? xlResponse,
+        http.Response? kidsResponse}) =>
     MockClient((request) async {
       if (request.url.path.contains("selfie")) {
         return http.Response(jsonEncode(_selfie), selfieStatus,
@@ -60,6 +76,11 @@ MockClient _client({int selfieStatus = 200, http.Response? xlResponse}) =>
       }
       if (request.url.path.contains("xlrun")) {
         return xlResponse ??
+            http.Response("<html>not found</html>", 200,
+                headers: {"content-type": "text/html; charset=utf-8"});
+      }
+      if (request.url.path.contains("kidsrun")) {
+        return kidsResponse ??
             http.Response("<html>not found</html>", 200,
                 headers: {"content-type": "text/html; charset=utf-8"});
       }
@@ -118,6 +139,30 @@ void main() {
         'treats a non-JSON XL response as "no XL runs" rather than a fetch '
         'failure — this is what the real endpoint answers for the vast '
         'majority of users who have no XL history', () async {
+      final resource = RunsResource(client: _client());
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(2));
+      expect(resource.loading, isFalse);
+    });
+
+    test('merges Kids runs in when the endpoint answers with JSON', () async {
+      final resource = RunsResource(
+          client: _client(
+              kidsResponse: http.Response(jsonEncode(_kids), 200,
+                  headers: _jsonHeaders)));
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(3));
+      expect(runs.where((r) => r.runType == RunType.kids), hasLength(1));
+    });
+
+    test(
+        'treats a non-JSON Kids response as "no Kids runs" rather than a '
+        'fetch failure — this is what the real endpoint answers for the '
+        'vast majority of users who have no Kids history', () async {
       final resource = RunsResource(client: _client());
 
       final runs = await resource.getByUserId(42);


### PR DESCRIPTION
## Summary
- Adds a new "KidsRun" stat card to the profile page, shown only for users with Kids run history: runs completed this year, total runs all-time, total distance, best (fastest) finish time, and the most recent run's date + location. Mirrors the `XLStats` card from #178/#193.
- New `KidsStats` model (`lib/state/kids_stats.dart`) with a pure `KidsStats.fromRuns(List<Run>)` factory — **no new network call**, same reasoning as the XL stats card: `RunsResource` already fetches `kidsrun/user/<id>` to build the Kids entries in "Твоите бягания" (#188), so this derives stats from that already-loaded `List<Run>` instead of hitting the same endpoint a second time.
- **Difference from XL:** every Kids run is the same fixed ~2km distance (`Run.kidsDistanceMeters`), so unlike XL — where distance varies per event and a raw fastest-time comparison isn't meaningful — both **total distance** (a plain sum, no unparseable-name caveat) and a single **best finish time** are directly comparable across every Kids run and are included here. XL's card deliberately left "best time" out for exactly the opposite reason.
- Returns `null` from `KidsStats.fromRuns` when the user has no Kids runs, so the profile page simply doesn't render the card — no all-zero placeholder.

## Likely files touched (as scoped in the issue)
- `lib/state/kids_stats.dart` — new `KidsStats` model.
- `lib/profile.dart` — new `buildKidsStatsCard`, wired in between the run-type cards and the runs chart.

## ⚠️ Branch dependency
This branch is based on **#192** (`claude-feat/kids-runs-list`), since `KidsStats` reuses `RunType.kids`/`Run.fromKidsJson`/`Run.kidsDistanceMeters` introduced there. #192 isn't merged yet, so this diff currently includes its commits too — recommend merging #192 first, then this one (it should then fast-forward to just the profile-stats commit), or rebasing this branch once it lands.

## Test plan
- [x] `flutter analyze` on changed files — no new issues beyond one pre-existing-style `unnecessary_this` info (matching that file's existing convention); verified by diffing analyzer output before/after.
- [x] `flutter test` — full suite passes, including new `test/state/kids_stats_test.dart`:
  - returns `null` with no Kids runs.
  - counts all-time vs. this-year runs, ignoring non-Kids runs mixed into the same list.
  - sums the fixed per-run distance (contrast comment vs. XL's parsed-and-possibly-missing distance).
  - best run is the fastest by time — meaningful here since every Kids run is the same fixed distance.
  - most recent run is picked by date, not list/insertion order.
- [x] **Manual verification — Android emulator (Pixel 7 API 36):** built and ran the app against the live production API, logged in as an existing user.
  - This account has no Kids run history, so `KidsStats.fromRuns` correctly returned `null` and the profile page rendered exactly as before — no new card, no regression to the existing selfie/official cards, milestone tiles, or charts. The Kids-specific stat computation and rendering itself is covered by the unit tests above rather than a live screenshot with real Kids data, since no such test account was available (same honest caveat as #192's verification).
- **iOS Simulator:** not run this pass — same one-time interactive `xcode-select` prompt limitation noted in prior PRs, not available in this automated environment.

Closes #187