### PR TITLE
test: cover StravaResource.createSummaryActivity's fastest-5km-window logic

### DIFF
--- a/fivekmrun_app_flutter/test/state/strava_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/strava_resource_test.dart
@@ -1,0 +1,136 @@
+import 'package:fivekmrun_flutter/state/strava_resource.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:strava_client/strava_client.dart';
+
+DetailedActivity _activityWithSplits(List<SplitsMetric> splits) {
+  return DetailedActivity(splitsMetric: splits);
+}
+
+SplitsMetric _split({required double distance, required int elapsedTime}) {
+  return SplitsMetric(distance: distance, elapsedTime: elapsedTime);
+}
+
+void main() {
+  final resource = StravaResource();
+
+  group('createSummaryActivity', () {
+    test('picks the contiguous window whose distance lands in the 5km filter range',
+        () {
+      // Five 1km splits at an even pace: any 5-split window sums to 5000m,
+      // which is inside (stravaFilterMinDistance, stravaFilterMaxDistance).
+      final activity = _activityWithSplits([
+        _split(distance: 1000, elapsedTime: 240),
+        _split(distance: 1000, elapsedTime: 240),
+        _split(distance: 1000, elapsedTime: 240),
+        _split(distance: 1000, elapsedTime: 240),
+        _split(distance: 1000, elapsedTime: 240),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 5000);
+      expect(summary.fastestSplit.elapsedTime, 1200);
+      expect(summary.detailedActivity, same(activity));
+    });
+
+    test('finds the fastest among several qualifying windows', () {
+      // Splits 0-4 sum to 5000m in 1300s; splits 1-5 also sum to 5000m but
+      // faster, at 1100s. The faster window must win.
+      final activity = _activityWithSplits([
+        _split(distance: 1000, elapsedTime: 300),
+        _split(distance: 1000, elapsedTime: 200),
+        _split(distance: 1000, elapsedTime: 200),
+        _split(distance: 1000, elapsedTime: 200),
+        _split(distance: 1000, elapsedTime: 300),
+        _split(distance: 1000, elapsedTime: 200),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 5000);
+      expect(summary.fastestSplit.elapsedTime, 1100);
+    });
+
+    test('skips a window that undershoots the minimum filter distance', () {
+      // Only 3km total — every window stays under stravaFilterMinDistance
+      // (4900m), so no window ever qualifies.
+      final activity = _activityWithSplits([
+        _split(distance: 1000, elapsedTime: 240),
+        _split(distance: 1000, elapsedTime: 240),
+        _split(distance: 1000, elapsedTime: 240),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 0);
+      expect(summary.fastestSplit.elapsedTime, 999999);
+    });
+
+    test('skips a window that overshoots the maximum filter distance', () {
+      // A single 6km split blows straight past stravaFilterMaxDistance
+      // (5300m) with no smaller window available to fall back on.
+      final activity = _activityWithSplits([
+        _split(distance: 6000, elapsedTime: 1500),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 0);
+      expect(summary.fastestSplit.elapsedTime, 999999);
+    });
+
+    test('excludes a window that lands exactly on the min boundary', () {
+      // dist must be strictly greater than stravaFilterMinDistance (4900).
+      final activity = _activityWithSplits([
+        _split(distance: 4900, elapsedTime: 1200),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 0);
+      expect(summary.fastestSplit.elapsedTime, 999999);
+    });
+
+    test('excludes a window that lands exactly on the max boundary', () {
+      // dist must be strictly less than stravaFilterMaxDistance (5300).
+      final activity = _activityWithSplits([
+        _split(distance: 5300, elapsedTime: 1300),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 0);
+      expect(summary.fastestSplit.elapsedTime, 999999);
+    });
+
+    test('a single split can qualify on its own when it lands in range', () {
+      final activity = _activityWithSplits([
+        _split(distance: 5100, elapsedTime: 1250),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 5100);
+      expect(summary.fastestSplit.elapsedTime, 1250);
+    });
+
+    test('finds a qualifying window that starts mid-activity', () {
+      // The first two splits are a slow warm-up that overshoots on its own;
+      // the real 5km effort starts at index 2.
+      final activity = _activityWithSplits([
+        _split(distance: 2000, elapsedTime: 700),
+        _split(distance: 2000, elapsedTime: 700),
+        _split(distance: 1000, elapsedTime: 230),
+        _split(distance: 1000, elapsedTime: 230),
+        _split(distance: 1000, elapsedTime: 230),
+        _split(distance: 1000, elapsedTime: 230),
+        _split(distance: 1000, elapsedTime: 230),
+      ]);
+
+      final summary = resource.createSummaryActivity(activity);
+
+      expect(summary.fastestSplit.distance, 5000);
+      expect(summary.fastestSplit.elapsedTime, 1150);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Nightly test-coverage fallback: all currently open `up-for-claude` issues (#185, #186, #187, #188, #177, #178) already have open PRs against them (#191–#196), so per the fallback rule this run picked an untested module instead.

`lib/state/strava_resource.dart` had zero test coverage. Most of the class needs a live `StravaClient` or Firebase Crashlytics to exercise (`authenticate`, `_assureAuthenticated`, `getThisWeekActivities`, `deAuthenticate`), which puts it out of scope for a fast host-side widget test. But `createSummaryActivity` is pure, self-contained logic: given an activity's per-km splits, it slides a window across them to find the fastest contiguous stretch whose distance falls inside the app's 5km filter...

## What's covered (`test/state/strava_resource_test.dart`)

- A window whose distance lands in the filter range is picked
- The fastest among several qualifying windows wins
- A window that undershoots the minimum distance is skipped
- A window that overshoots the maximum distance is skipped
- Exact-boundary exclusion: the check is strictly `>` / `<`, so a window landing exactly on 4900m or exactly on 5300m is excluded
- A single split can qualify on its own
- A qualifying window can start mid-activity (after a slower warm-up segment)

All fixtures are built directly with the `strava_client` package's own `DetailedActivity`/`SplitsMetric` constructors — no mocking needed since the method takes a `DetailedActivity` and returns a `StravaSummaryRun` synchronously.

## Test plan

- [x] `flutter analyze` — clean (pre-existing unrelated warnings only, in files this PR doesn't touch: `lib/push_notifications_manager.dart`, `lib/timekeeping/chronometer_view.dart`)
- [x] `flutter test` — full suite green, 151 tests passed including the 8 new ones
- Not applicable to run in-app: this change is test-only, no `lib/` behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)