### PR TITLE
docs: dispatch the Huawei workflow from /release

### DIFF
--- a/fivekmrun_app_flutter/.claude/commands/release.md
+++ b/fivekmrun_app_flutter/.claude/commands/release.md
@@ -35,16 +35,25 @@ Prepare a new release of the app. Follow these steps in order.
    gh release create vX.Y.Z --repo 5kmrun-bg/fivekmrun-app --title "vX.Y.Z" --notes "..."
    ```
 
-8. **Trigger the deployment workflows** — Both workflows use `workflow_dispatch`. Trigger them via the GitHub CLI:
+8. **Trigger the deployment workflows** — All three workflows use `workflow_dispatch`. Trigger them via the GitHub CLI:
    ```
    gh workflow run upload-appstore.yml --repo 5kmrun-bg/fivekmrun-app
    gh workflow run upload-playstore.yml --repo 5kmrun-bg/fivekmrun-app
+   gh workflow run upload-huawei.yml --repo 5kmrun-bg/fivekmrun-app
    ```
+
+   The Huawei run takes noticeably longer than its build suggests: after uploading
+   the APK it waits for AppGallery to compile the package (up to 6 minutes) before
+   submitting for review. A run sitting on "package still compiling" is healthy.
+
+   Unlike the other two, a successful Huawei run ends with the build **already
+   submitted for review** — no console step is needed.
 
    After triggering, report these links so the user can monitor and review everything directly:
    - **GitHub Release:** `https://github.com/5kmrun-bg/fivekmrun-app/releases/tag/vX.Y.Z`
    - **App Store Connect:** `https://appstoreconnect.apple.com/apps/1489549617/testflight/ios`
    - **Google Play Console:** `https://play.google.com/console/developers/app/bg.fivekmpark.fivekmrun/tracks/production`
+   - **AppGallery Connect:** `https://developer.huawei.com/consumer/en/service/josp/agc/index.html#/myApp/109680919`
    - **iOS workflow run:** (URL returned by `gh run list`)
 
 Note that steps 3, 5, 6 and 8 push to `master` and publish to the app stores. These are the intended behaviour of this command — the general "always open a PR" rule in `CLAUDE.md` does not apply here.


### PR DESCRIPTION
Follow-up to #201. Closes the `/release` item of #140.

Now that the AppGallery pipeline works individually, `/release` step 8 dispatches all three stores rather than leaving Huawei as a manual job.

## Changes

- Third `gh workflow run upload-huawei.yml` alongside the App Store and Play Store dispatches
- **AppGallery Connect** monitoring link added to the reported links
- Two notes at the point of use:
  - The Huawei run is slower than its build implies — it waits up to 6 minutes for AGC to compile the uploaded package before submitting. A run sitting on *"package still compiling"* is healthy, not stuck.
  - Unlike the other two stores, a green Huawei run means the build is **already submitted for review** — no console step.

## Why this is safe to add now

Verified end to end on run [30206217782](https://github.com/5kmrun-bg/fivekmrun-app/actions/runs/30206217782) plus a live submit:

```
token          200  ret.code 0
upload-url     200  ret.code 0
OBS upload     200  (attempt 1)
app-file-info  200  ret.code 0   pkgVersion 2003238141632193664
app-submit     200  ret.code 0   success
```

`app-info` `releaseState` moved **7 → 5**, so the submission took effect rather than merely returning a success code.

## Still open on #140

The last acceptance criterion — verification against a **real** release — is by definition the next `/release`. The build currently in Huawei's queue is version-labelled `3.18.0+474` while carrying ~60 commits of post-tag work; that mismatch was accepted deliberately to exercise `app-submit`, and resolves itself on the next properly-versioned release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)