### PR TITLE
fix: guard the Strava auth retry path against unhandled Fault exceptions

### DIFF
--- a/fivekmrun_app_flutter/lib/state/strava_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/strava_resource.dart
@@ -7,6 +7,66 @@ import 'package:strava_client/strava_client.dart';
 
 typedef StravaCallback<T> = Future<T> Function(StravaClient strava);
 
+/// Describes an error thrown by the strava_client package for logging.
+///
+/// [Fault] (the package's error model for a failed API call) has no
+/// `toString()` override, so an uncaught one only ever logs as the useless
+/// "Instance of 'Fault'". This surfaces the actual message/error codes
+/// instead, falling back to `error.toString()` for anything else.
+String describeStravaError(Object error) {
+  if (error is Fault) {
+    final codes = (error.errors ?? [])
+        .map((e) => [e.resource, e.field, e.code]
+            .where((part) => part != null)
+            .join(":"))
+        .where((s) => s.isNotEmpty)
+        .join(", ");
+    final message = error.message ?? "no message";
+    return codes.isEmpty ? message : "$message ($codes)";
+  }
+  return error.toString();
+}
+
+/// Reports an error/stackTrace pair with a human-readable [reason], e.g. to
+/// Crashlytics. Injected so callers can be unit-tested without Firebase.
+typedef StravaErrorReporter = void Function(
+    Object error, StackTrace stackTrace, String reason);
+
+void _reportStravaErrorToCrashlytics(
+    Object error, StackTrace stackTrace, String reason) {
+  FirebaseCrashlytics.instance.recordError(error, stackTrace, reason: reason);
+}
+
+/// Fetches the authenticated athlete via [getAthlete], re-authenticating and
+/// retrying once if the first attempt fails (e.g. an expired/revoked token).
+///
+/// Both attempts are guarded: if [getAthlete] fails again after
+/// [reAuthenticate] runs, this returns `null` instead of letting the second
+/// failure escape unhandled, and each failure is reported via [reportError]
+/// with the underlying message rather than a bare "Instance of 'Fault'".
+Future<DetailedAthlete?> fetchAuthenticatedAthleteWithRetry(
+  Future<DetailedAthlete> Function() getAthlete,
+  Future<void> Function() reAuthenticate, {
+  StravaErrorReporter reportError = _reportStravaErrorToCrashlytics,
+}) async {
+  try {
+    return await getAthlete();
+  } catch (error, stackTrace) {
+    reportError(error, stackTrace,
+        "Strava getAuthenticatedAthlete failed: ${describeStravaError(error)}");
+  }
+
+  await reAuthenticate();
+
+  try {
+    return await getAthlete();
+  } catch (error, stackTrace) {
+    reportError(error, stackTrace,
+        "Strava getAuthenticatedAthlete retry failed: ${describeStravaError(error)}");
+    return null;
+  }
+}
+
 class StravaResource extends ChangeNotifier {
   static StravaClient? strava;
 
@@ -37,13 +97,16 @@ class StravaResource extends ChangeNotifier {
   }
 
   Future<bool> _assureAuthenticated(StravaClient strava) async {
-    DetailedAthlete athlete;
-    try {
-      athlete = await strava.athletes.getAuthenticatedAthlete();
-    } catch (e) {
-      this.deAuthenticate();
-      this.authenticate();
-      athlete = await strava.athletes.getAuthenticatedAthlete();
+    final athlete = await fetchAuthenticatedAthleteWithRetry(
+      strava.athletes.getAuthenticatedAthlete,
+      () async {
+        await this.deAuthenticate();
+        await this.authenticate();
+      },
+    );
+
+    if (athlete == null) {
+      return false;
     }
 
     FirebaseCrashlytics.instance.setCustomKey("stravaUserID", athlete.id);
@@ -67,9 +130,18 @@ class StravaResource extends ChangeNotifier {
               redirectUrl: "fivekmrun://redirect/",
               callbackUrlScheme: "fivekmrun")
           .then((t) => true)
-          .onError((error, stackTrace) {
-        FirebaseCrashlytics.instance.recordError(error, stackTrace);
-        strava.authentication.deAuthorize();
+          .onError((error, stackTrace) async {
+        FirebaseCrashlytics.instance.recordError(error, stackTrace,
+            reason: "Strava authenticate failed: "
+                "${describeStravaError(error!)}");
+        try {
+          await strava.authentication.deAuthorize();
+        } catch (deAuthorizeError, deAuthorizeStackTrace) {
+          FirebaseCrashlytics.instance.recordError(
+              deAuthorizeError, deAuthorizeStackTrace,
+              reason: "Strava deAuthorize after failed authenticate failed: "
+                  "${describeStravaError(deAuthorizeError)}");
+        }
         return false;
       });
 
@@ -79,7 +151,7 @@ class StravaResource extends ChangeNotifier {
     });
   }
 
-  void deAuthenticate() async {
+  Future<void> deAuthenticate() async {
     return _withStrava((strava) async {
       FirebaseCrashlytics.instance.log("Strava deAuthenticate");
       FirebaseCrashlytics.instance.setCustomKey("stravaUserID", -1);

--- a/fivekmrun_app_flutter/test/state/strava_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/strava_resource_test.dart
@@ -133,4 +133,119 @@ void main() {
       expect(summary.fastestSplit.elapsedTime, 1150);
     });
   });
+
+  group('describeStravaError', () {
+    test('describes a Fault by its message', () {
+      final fault = Fault(message: "Authorization Error");
+
+      expect(describeStravaError(fault), "Authorization Error");
+    });
+
+    test('appends error codes from a Fault when present', () {
+      final fault = Fault(message: "Bad Request", errors: [
+        Error(resource: "Application", field: "refresh_token", code: "invalid")
+      ]);
+
+      expect(describeStravaError(fault),
+          "Bad Request (Application:refresh_token:invalid)");
+    });
+
+    test('falls back to toString for a non-Fault error', () {
+      final error = Exception("network unreachable");
+
+      expect(describeStravaError(error), error.toString());
+    });
+  });
+
+  group('fetchAuthenticatedAthleteWithRetry', () {
+    DetailedAthlete athlete(int id) => DetailedAthlete(
+          id: id,
+          username: "runner",
+          resourceState: 3,
+          firstname: "First",
+          lastname: "Last",
+          city: "Sofia",
+          state: "",
+          country: "Bulgaria",
+          sex: "M",
+          premium: false,
+          createdAt: null,
+          updatedAt: null,
+          badgeTypeId: 0,
+          profileMedium: null,
+          profile: null,
+          friend: null,
+          follower: null,
+          followerCount: 0,
+          friendCount: 0,
+          mutualFriendCount: 0,
+          athleteType: 0,
+          datePreference: "%m/%d/%Y",
+          measurementPreference: "meters",
+          clubs: [],
+          ftp: null,
+          weight: null,
+          bikes: [],
+          shoes: [],
+        );
+
+    test('returns the athlete without retrying when the first call succeeds',
+        () async {
+      var reAuthenticateCalls = 0;
+
+      final result = await fetchAuthenticatedAthleteWithRetry(
+        () async => athlete(42),
+        () async => reAuthenticateCalls++,
+        reportError: (_, __, ___) {},
+      );
+
+      expect(result?.id, 42);
+      expect(reAuthenticateCalls, 0);
+    });
+
+    test('re-authenticates and retries once when the first call throws',
+        () async {
+      var callCount = 0;
+      var reAuthenticateCalls = 0;
+      final reportedReasons = <String>[];
+
+      final result = await fetchAuthenticatedAthleteWithRetry(
+        () async {
+          callCount++;
+          if (callCount == 1) {
+            throw Fault(message: "Authorization Error");
+          }
+          return athlete(7);
+        },
+        () async => reAuthenticateCalls++,
+        reportError: (_, __, reason) => reportedReasons.add(reason),
+      );
+
+      expect(result?.id, 7);
+      expect(reAuthenticateCalls, 1);
+      expect(reportedReasons, hasLength(1));
+      expect(reportedReasons.single, contains("Authorization Error"));
+    });
+
+    // Regression test for the unhandled 'Fault' exception (#167): before the
+    // fix, the retry call was made without a guarding try/catch, so a second
+    // failure escaped as an unhandled exception instead of being reported and
+    // resolved to null.
+    test('returns null instead of throwing when the retry also fails',
+        () async {
+      var reAuthenticateCalls = 0;
+      final reportedReasons = <String>[];
+
+      final result = await fetchAuthenticatedAthleteWithRetry(
+        () async => throw Fault(message: "invalid_grant"),
+        () async => reAuthenticateCalls++,
+        reportError: (_, __, reason) => reportedReasons.add(reason),
+      );
+
+      expect(result, isNull);
+      expect(reAuthenticateCalls, 1);
+      expect(reportedReasons, hasLength(2));
+      expect(reportedReasons.every((r) => r.contains("invalid_grant")), isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Returning from the Strava OAuth flow could throw an unhandled `Fault` (the `strava_client` package's API error model for a failed call) via two unguarded paths in `lib/state/strava_resource.dart`:

1. **`_assureAuthenticated`**: if the first `getAuthenticatedAthlete()` call failed, it fired `deAuthenticate()`/`authenticate()` without awaiting them, then immediately retried `getAuthenticatedAthlete()` with no surrounding try/catch. If the retry also failed (the token wasn't actually refreshed yet, since the re-auth futures hadn't completed), the `Fault` escaped as an unhandled exception.
2. **`authenticate()`**'s `.onError` handler called `strava.authentication.deAuthorize()` fire-and-forget (not awaited, not wrapped). If that call itself failed with a `Fault` (e.g. deauthorizing with an already-invalid access token), it became a second, truly unhandled exception — right after the first `Fault` had already been logged, matching the reported log sequence exactly (a `recordError` log line for "Instance of 'Fault'" immediately followed by an unhandled-exception crash).

Neither `Fault` has a `toString()` override, so both failures also logged as the useless `"Instance of 'Fault'"` with no way to diagnose the real cause.

## Fix
- Extracted the retry logic into a standalone, unit-testable `fetchAuthenticatedAthleteWithRetry()` function: both the initial attempt and the retry are now guarded by try/catch, the re-authentication step is properly awaited before retrying, and a persistent failure resolves to `null` instead of throwing.
- `deAuthorize()` inside `authenticate()`'s error handler is now awaited inside its own try/catch, so its own failures are caught and reported instead of escaping unhandled.
- Added `describeStravaError()`, which surfaces `Fault.message` and any `Error` codes (resource/field/code) instead of the bare `"Instance of 'Fault'"`, used everywhere a Strava error is reported to Crashlytics.
- Fixed `deAuthenticate()`'s declared return type from `void` to `Future<void>` so callers can actually await it (needed for the retry ordering fix above).

## Test plan
- [x] **Test-driven fix**: added `test/state/strava_resource_test.dart` coverage for `describeStravaError` and `fetchAuthenticatedAthleteWithRetry`. Confirmed red→green: stashing the production change made the new tests fail to compile (`Method not found`), then pass cleanly once the fix was reapplied.
  - `describeStravaError` — Fault message only, Fault message + error codes, and non-Fault fallback to `toString()`.
  - `fetchAuthenticatedAthleteWithRetry` — succeeds without retrying; retries once and succeeds after a re-auth; **regression test**: retry also fails → returns `null` instead of throwing (this is the exact unhandled-exception scenario from #167).
- [x] `flutter analyze` on changed files — no new issues; same 30 pre-existing info-level lints before and after (diffed output to confirm).
- [x] `flutter test` — full suite passes (all tests green).
- [x] **Manual verification — Android emulator (Pixel 7 API 36)**: built and ran the app against the live production API, logged in as an existing user.
  - App launched and rendered the profile screen normally — no regression from the refactor.
  - Navigated to Settings → confirmed the "Strava интеграция" connect button renders and `isAuthenticated()` runs through the (now-guarded) code path without crashing.
  - Could not reproduce the exact live OAuth `Fault` scenario in this environment (this test account has no real Strava connection and CI-only secrets are placeholders here), so the unit tests are the primary verification for the actual bug — they exercise the retry/guard logic directly with injected fakes.

Closes #167