### PR TITLE
test: add coverage for login/helpers.dart

### DIFF
--- a/fivekmrun_app_flutter/test/login/helpers_test.dart
+++ b/fivekmrun_app_flutter/test/login/helpers_test.dart
@@ -1,0 +1,102 @@
+import 'package:fivekmrun_flutter/login/helpers.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('parseUserId', () {
+    test('parses a plain positive integer', () {
+      expect(parseUserId('12345'), 12345);
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(parseUserId('  42  '), 42);
+    });
+
+    test('returns null for an empty string', () {
+      expect(parseUserId(''), isNull);
+    });
+
+    test('returns null for a whitespace-only string', () {
+      expect(parseUserId('   '), isNull);
+    });
+
+    test('returns null for non-numeric input', () {
+      expect(parseUserId('abc'), isNull);
+    });
+
+    test('returns null for zero', () {
+      expect(parseUserId('0'), isNull);
+    });
+
+    test('returns null for a negative number', () {
+      expect(parseUserId('-5'), isNull);
+    });
+
+    test('returns null for a decimal value', () {
+      expect(parseUserId('12.5'), isNull);
+    });
+  });
+
+  group('InputHelpers.decoration', () {
+    test('sets the label text to the given hint', () {
+      final decoration = InputHelpers.decoration('email');
+      expect(decoration.labelText, 'email');
+    });
+
+    test('uses a square-cornered outline border', () {
+      final decoration = InputHelpers.decoration('email');
+      final border = decoration.border as OutlineInputBorder;
+      expect(border.borderRadius, BorderRadius.all(Radius.circular(0)));
+    });
+  });
+
+  group('getSwatch', () {
+    test('returns all ten Material swatch steps', () {
+      final swatch = getSwatch(Colors.blue);
+      expect(
+        swatch.keys.toSet(),
+        {50, 100, 200, 300, 400, 500, 600, 700, 800, 900},
+      );
+    });
+
+    test('keeps the input color as the 500 step', () {
+      final color = Color(0xFF336699);
+      final swatch = getSwatch(color);
+      expect(swatch[500], color);
+    });
+
+    test('gets lighter as the step number decreases from 500', () {
+      final swatch = getSwatch(Colors.blue);
+      final lightness50 = HSLColor.fromColor(swatch[50]!).lightness;
+      final lightness100 = HSLColor.fromColor(swatch[100]!).lightness;
+      final lightness500 = HSLColor.fromColor(swatch[500]!).lightness;
+      expect(lightness50, greaterThan(lightness100));
+      expect(lightness100, greaterThan(lightness500));
+    });
+
+    test('gets darker as the step number increases from 500', () {
+      final swatch = getSwatch(Colors.blue);
+      final lightness500 = HSLColor.fromColor(swatch[500]!).lightness;
+      final lightness800 = HSLColor.fromColor(swatch[800]!).lightness;
+      final lightness900 = HSLColor.fromColor(swatch[900]!).lightness;
+      expect(lightness800, lessThan(lightness500));
+      expect(lightness900, lessThan(lightness800));
+    });
+  });
+
+  group('getColor', () {
+    test('builds a MaterialColor whose value matches the input color', () {
+      final color = Color(0xFF336699);
+      final materialColor = getColor(color);
+      expect(materialColor.value, color.value);
+    });
+
+    test('exposes the same swatch getSwatch would produce', () {
+      final color = Colors.green;
+      final materialColor = getColor(color);
+      final swatch = getSwatch(color);
+      expect(materialColor[500], swatch[500]);
+      expect(materialColor[900], swatch[900]);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Nightly `up-for-claude` sweep found no eligible issue to work: `#204` (language switcher), `#188`/`#187` (KidsRun) already have open PRs; `#168` (pull-to-refresh guards) is stale — both parts described in the issue are already fixed on `master`; `#200` (manual barcode entry) has an explicit "please confirm before implementing" open question about the physical place-token padding format, and guessing wrong risks corrupting real race-timing exports, so it wasn't attempted; `#199` (What's New sc...

Falling back to the test-coverage path instead: `lib/login/helpers.dart` had no corresponding `test/login/helpers_test.dart`, and it's pure, dependency-free logic worth covering — `parseUserId` (input validation used by the ID-login flow), `InputHelpers.decoration`, and the `getSwatch`/`getColor` Material-swatch generator (drives the app's dynamic primary-color theming in `main.dart`).

## What's covered
- `parseUserId`: valid input, whitespace trimming, empty/whitespace-only, non-numeric, zero, negative, and decimal input — all the paths that decide whether the "login with ID" flow accepts a value.
- `InputHelpers.decoration`: label text and the square-cornered border shape.
- `getSwatch`: produces all ten swatch keys, keeps the input color at `500`, and gets monotonically lighter below / darker above that step.
- `getColor`: wraps `getSwatch` into a `MaterialColor` with a matching `.value` and consistent swatch entries.

## Test plan
- `flutter analyze` on the changed files: only pre-existing `info`-level style suggestions (`prefer_const_constructors`, a `Color.value` deprecation already used the same way in the source file), no new warnings/errors.
- `flutter test test/login/helpers_test.dart`: all 16 new tests pass.
- `flutter test` (full suite): all tests pass, no regressions.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>