### PR TITLE
fix: wire up pull-to-refresh on the offline chart tab

### DIFF
--- a/fivekmrun_app_flutter/lib/offline_chart/offline_chart_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/offline_chart_page.dart
@@ -1,3 +1,4 @@
+import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/results_list.dart';
 import 'package:fivekmrun_flutter/common/select_button.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
@@ -11,7 +12,17 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 
 class OfflineChartPage extends StatefulWidget {
-  OfflineChartPage({Key? key}) : super(key: key);
+  /// Injectable for tests; defaults to real resources in production.
+  OfflineChartPage({
+    Key? key,
+    OfflineResultsResource? lastWeekResource,
+    OfflineResultsResource? thisWeekResource,
+  })  : lastWeekResource = lastWeekResource ?? OfflineResultsResource(),
+        thisWeekResource = thisWeekResource ?? OfflineResultsResource(),
+        super(key: key);
+
+  final OfflineResultsResource lastWeekResource;
+  final OfflineResultsResource thisWeekResource;
 
   @override
   _OfflineChartPageState createState() => _OfflineChartPageState();
@@ -20,8 +31,6 @@ class OfflineChartPage extends StatefulWidget {
 class _OfflineChartPageState extends State<OfflineChartPage> {
   bool thisWeekSelected = true;
   List<Result>? results;
-  OfflineResultsResource lastWeekResource = OfflineResultsResource();
-  OfflineResultsResource thisWeekResource = OfflineResultsResource();
 
   selectThisWeek() {
     if (this.thisWeekSelected) {
@@ -121,22 +130,34 @@ class _OfflineChartPageState extends State<OfflineChartPage> {
     this._loadThisWeekResult();
   }
 
-  _loadLastWeekResult() {
+  Future<void> _loadLastWeekResult() async {
     setState(() {
       this.results = null;
-      this.lastWeekResource.getPastWeekResults().then((loadedResults) {
-        this.setState(() => this.results = loadedResults);
-      });
     });
+    final loadedResults =
+        await this.widget.lastWeekResource.getPastWeekResults();
+    if (!this.mounted) return;
+    this.setState(() => this.results = loadedResults);
   }
 
-  _loadThisWeekResult() {
+  Future<void> _loadThisWeekResult() async {
     setState(() {
       this.results = null;
-      this.thisWeekResource.getThisWeekResults().then((loadedResults) {
-        this.setState(() => this.results = loadedResults);
-      });
     });
+    final loadedResults =
+        await this.widget.thisWeekResource.getThisWeekResults();
+    if (!this.mounted) return;
+    this.setState(() => this.results = loadedResults);
+  }
+
+  /// Backs the pull-to-refresh gesture on this tab, reloading whichever week
+  /// is currently selected. Kept separate from [refreshAllData]: this page
+  /// has its own week-scoped resources rather than the shared ones that
+  /// helper refreshes.
+  Future<void> _refresh() {
+    return this.thisWeekSelected
+        ? this._loadThisWeekResult()
+        : this._loadLastWeekResult();
   }
 
   @override
@@ -168,73 +189,76 @@ class _OfflineChartPageState extends State<OfflineChartPage> {
           ),
         ),
       ),
-      body: Center(
-        child: Column(
-          children: <Widget>[
-            Row(
-              children: <Widget>[
-                SelectButton(
-                  text: AppLocalizations.of(context)!
-                      .offline_chart_page_previous_week,
-                  onPressed: this.selectLastWeek,
-                  selected: !this.thisWeekSelected,
-                ),
-                SelectButton(
-                  text: AppLocalizations.of(context)!
-                      .offline_chart_page_current_week,
-                  onPressed: this.selectThisWeek,
-                  selected: this.thisWeekSelected,
-                ),
-              ],
-            ),
-            Expanded(child: this._buildResults()),
-            Row(
-              children: <Widget>[
-                Padding(
-                  padding: const EdgeInsets.only(left: 8, right: 8),
-                  child: ElevatedButton(
-                    onPressed: () => this.goToAddEntry(),
-                    child: Row(
-                      children: [
-                        Text(
-                            AppLocalizations.of(context)!
-                                .offline_chart_page_join,
-                            style: TextStyle()),
-                        Padding(
-                          padding: const EdgeInsets.only(left: 8, right: 8),
-                          child: Icon(Icons.add_circle_outline),
-                        )
-                      ],
-                    ),
+      body: RefreshIndicator(
+        onRefresh: this._refresh,
+        child: Center(
+          child: Column(
+            children: <Widget>[
+              Row(
+                children: <Widget>[
+                  SelectButton(
+                    text: AppLocalizations.of(context)!
+                        .offline_chart_page_previous_week,
+                    onPressed: this.selectLastWeek,
+                    selected: !this.thisWeekSelected,
                   ),
-                ),
-                Padding(
-                  padding: const EdgeInsets.all(8.0),
-                  child: OutlinedButton(
-                      onPressed: () => {
-                            launchUrl(
-                              Uri.parse("https://5kmrun.bg/selfie/ofc"),
-                            )
-                          },
+                  SelectButton(
+                    text: AppLocalizations.of(context)!
+                        .offline_chart_page_current_week,
+                    onPressed: this.selectThisWeek,
+                    selected: this.thisWeekSelected,
+                  ),
+                ],
+              ),
+              Expanded(child: this._buildResults()),
+              Row(
+                children: <Widget>[
+                  Padding(
+                    padding: const EdgeInsets.only(left: 8, right: 8),
+                    child: ElevatedButton(
+                      onPressed: () => this.goToAddEntry(),
                       child: Row(
                         children: [
                           Text(
-                            AppLocalizations.of(context)!
-                                .offline_chart_page_results,
-                            style: TextStyle(
-                              fontSize: 8,
-                            ),
-                          ),
+                              AppLocalizations.of(context)!
+                                  .offline_chart_page_join,
+                              style: TextStyle()),
                           Padding(
-                            padding: const EdgeInsets.only(left: 8.0),
-                            child: Icon(Icons.open_in_browser),
+                            padding: const EdgeInsets.only(left: 8, right: 8),
+                            child: Icon(Icons.add_circle_outline),
                           )
                         ],
-                      )),
-                )
-              ],
-            )
-          ],
+                      ),
+                    ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.all(8.0),
+                    child: OutlinedButton(
+                        onPressed: () => {
+                              launchUrl(
+                                Uri.parse("https://5kmrun.bg/selfie/ofc"),
+                              )
+                            },
+                        child: Row(
+                          children: [
+                            Text(
+                              AppLocalizations.of(context)!
+                                  .offline_chart_page_results,
+                              style: TextStyle(
+                                fontSize: 8,
+                              ),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(left: 8.0),
+                              child: Icon(Icons.open_in_browser),
+                            )
+                          ],
+                        )),
+                  )
+                ],
+              )
+            ],
+          ),
         ),
       ),
     );
@@ -242,11 +266,10 @@ class _OfflineChartPageState extends State<OfflineChartPage> {
 
   Widget _buildResults() {
     if (this.results == null) {
-      return Center(child: CircularProgressIndicator());
+      return refreshableMessage(CircularProgressIndicator());
     } else if (this.results?.length == 0) {
-      return Center(
-          child: Text(
-              AppLocalizations.of(context)!.offline_chart_page_no_results));
+      return refreshableMessage(
+          Text(AppLocalizations.of(context)!.offline_chart_page_no_results));
     } else {
       return ResultsList(results: this.results!);
     }

--- a/fivekmrun_app_flutter/test/offline_chart/offline_chart_page_test.dart
+++ b/fivekmrun_app_flutter/test/offline_chart/offline_chart_page_test.dart
@@ -1,0 +1,53 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/offline_chart/offline_chart_page.dart';
+import 'package:fivekmrun_flutter/state/offline_results_resource.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+
+import '../localized_app.dart';
+
+const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+void main() {
+  testWidgets(
+      'wires a RefreshIndicator so pull-to-refresh reloads the current week',
+      (tester) async {
+    final client = MockClient((_) async =>
+        http.Response(jsonEncode({"runners": []}), 200, headers: _jsonHeaders));
+
+    await tester.pumpWidget(localizedApp(OfflineChartPage(
+      thisWeekResource: OfflineResultsResource(client: client),
+      lastWeekResource: OfflineResultsResource(client: client),
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RefreshIndicator), findsOneWidget);
+  });
+
+  testWidgets('reloads results when the RefreshIndicator is triggered',
+      (tester) async {
+    var requestCount = 0;
+    final client = MockClient((_) async {
+      requestCount++;
+      return http.Response(jsonEncode({"runners": []}), 200,
+          headers: _jsonHeaders);
+    });
+
+    await tester.pumpWidget(localizedApp(OfflineChartPage(
+      thisWeekResource: OfflineResultsResource(client: client),
+      lastWeekResource: OfflineResultsResource(client: client),
+    )));
+    await tester.pumpAndSettle();
+
+    final requestsBeforeRefresh = requestCount;
+
+    await tester.fling(
+        find.byType(RefreshIndicator), const Offset(0, 300), 1000);
+    await tester.pumpAndSettle();
+
+    expect(requestCount, greaterThan(requestsBeforeRefresh));
+  });
+}


### PR DESCRIPTION
## Summary
The offline chart tab ("Selfie" leaderboard) had no `RefreshIndicator`, so the pull-to-refresh gesture present on every other tab did nothing there — the doc comment on `refreshAllData` promised it worked "on any tab," but this tab was never wired in.

This addresses item 2 of #168. Item 1 (unguarded nullable `userId` in `refreshAllData`) turned out to already be fixed on `master` — the current code already guards `runsRes.getByUserId(userId)` behind `if (userId != null)`, and the doc comment is already scoped correctly to the profile/runs/events tabs rather than claiming "every screen." No change was needed there; I only touched the offline chart tab.

## Changes
- `lib/offline_chart/offline_chart_page.dart`:
  - Wrapped the tab body in a `RefreshIndicator` whose `onRefresh` reloads whichever week (current/previous) is currently selected.
  - `_loadThisWeekResult`/`_loadLastWeekResult` now return `Future<void>` (needed so `RefreshIndicator` can await them) and add a `mounted` check before the post-await `setState`, per project convention.
  - The page's two `OfflineResultsResource` instances are now constructor-injectable (defaulting to real instances), mirroring the same pattern `OfflineResultsResource` itself already uses for its `http.Client` — this is what makes the new widget test possible without hitting the network.
  - Loading/empty states now use the existing `refreshableMessage` helper (already used by the other pull-to-refresh tabs) so the gesture also works while loading or when a week has no results.

## Test plan
- New `test/offline_chart/offline_chart_page_test.dart` (2 widget tests, using a `MockClient` like `offline_results_resource_test.dart` does):
  - Asserts the page renders a `RefreshIndicator`.
  - Simulates the pull gesture (`tester.fling`) and asserts it triggers a new network request.
- `flutter analyze` on the changed files: no new errors/warnings — only the same `info`-level style suggestions (`unnecessary_this`, etc.) already present throughout this file.
- `flutter test` (full suite): all 224 tests pass, no regressions.
- Manually verified on a booted Android emulator (Pixel 7 API 36): navigated to the "Selfie" tab, swiped down, and confirmed the pull-to-refresh spinner now appears and a refresh is triggered (previously the swipe did nothing). iOS Simulator verification was blocked by an unrelated pre-existing environment issue (`ios/Runner/pass_certificate.p12` missing, an Xcode build-phase dependency not covered by the documented `secrets.dart` placeholder setup) — not something introduced by this change.

## Manual testing instructions
1. Open the app, go to the "Selfie" tab (trophy icon).
2. Swipe down from the top of the list.
3. The refresh spinner should appear and the list should reload (try on both "Current week" and "Previous week").

Closes #168