### PR TITLE
feat: add a What's New screen and post-update popup

### DIFF
--- a/fivekmrun_app_flutter/.claude/commands/release.md
+++ b/fivekmrun_app_flutter/.claude/commands/release.md
@@ -30,6 +30,10 @@ Prepare a new release of the app. Follow these steps in order.
 
    Commit both files directly to `master` with message `chore: add release notes for vX.Y.Z` and push.
 
+   **Also update the in-app "What's new" archive (`assets/whats_new.json`)** — but only for a release with genuinely significant, user-facing changes. Skip this sub-step entirely for a patch or tech-only release (dependency bumps, refactors, CI, "stability improvements" with nothing else): the app already treats a version with no entry as silent (no popup), which is correct, so don't manufacture an entry just to have one.
+
+   Propose a trimmed bullet list drawn from the same changes as the store notes (reuse them if they're already a good fit) and **ask the user to confirm or edit the list** before writing anything — don't derive it silently from the commit log. Once confirmed, add a new top-level `"X.Y.Z"` key to `assets/whats_new.json` with `bg` and `en` bullet arrays, keeping existing entries untouched. Commit it together with the two `whatsnew/` files in the same commit.
+
 7. **Create a GitHub Release** — Create a GitHub Release from the tag using the English release notes as the body:
    ```
    gh release create vX.Y.Z --repo 5kmrun-bg/fivekmrun-app --title "vX.Y.Z" --notes "..."

--- a/fivekmrun_app_flutter/assets/whats_new.json
+++ b/fivekmrun_app_flutter/assets/whats_new.json
@@ -1,0 +1,36 @@
+{
+  "3.18.0": {
+    "bg": [
+      "Дръпни надолу, за да опресниш профила, бяганията и събитията",
+      "Поддръжка на най-новата версия на Android",
+      "Отстранен проблем при зареждане на профила",
+      "Корекции на грешки и подобрения в стабилността"
+    ],
+    "en": [
+      "Pull down to refresh your profile, runs and events",
+      "Support for the latest version of Android",
+      "Fixed an issue when loading your profile",
+      "Bug fixes and stability improvements"
+    ]
+  },
+  "3.17.0": {
+    "bg": [
+      "Подобрен баркод скенер — по-бързо и точно сканиране",
+      "Звуков сигнал при успешно сканиране на финала",
+      "Баркодът се показва и без интернет връзка",
+      "Най-новите резултати са най-отгоре",
+      "Коригирана автентикация със Strava",
+      "Начална поддръжка на хронометриране",
+      "Корекции на грешки и подобрения"
+    ],
+    "en": [
+      "Improved barcode scanner — faster and more accurate scanning",
+      "Sound feedback when your barcode is scanned at the finish line",
+      "Barcode now works without an internet connection",
+      "Newest results appear at the top",
+      "Fixed Strava authentication on Android",
+      "Initial timekeeping support",
+      "Bug fixes and stability improvements"
+    ]
+  }
+}

--- a/fivekmrun_app_flutter/lib/constants.dart
+++ b/fivekmrun_app_flutter/lib/constants.dart
@@ -19,6 +19,7 @@ const String key_userId = "5kmrun_UserID";
 const String key_token = "5kmrun_Token";
 const String key_tokenTimestamp = "5kmrun_Token_Created";
 const int tokenExpiryDays = 30;
+const String key_lastSeenWhatsNewVersion = "5kmrun_LastSeenWhatsNewVersion";
 
 const int stravaFilterMinDistance = 4900;
 const int stravaFilterMaxDistance = 5300;

--- a/fivekmrun_app_flutter/lib/home.dart
+++ b/fivekmrun_app_flutter/lib/home.dart
@@ -13,8 +13,10 @@ import 'package:fivekmrun_flutter/runs/run_details_page.dart';
 import 'package:fivekmrun_flutter/runs/user_runs_page.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
 import 'package:fivekmrun_flutter/state/events_resource.dart';
+import 'package:fivekmrun_flutter/state/local_storage_resource.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:fivekmrun_flutter/whats_new/whats_new_manager.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
@@ -152,7 +154,21 @@ class _HomeState extends State<Home> with AfterLayoutMixin<Home> {
 
   @override
   void afterFirstLayout(BuildContext context) {
-    AppRatingManager(context);
+    _showWhatsNewThenRating(context);
+  }
+
+  /// The what's-new popup takes precedence on an update launch; if it shows,
+  /// the rating dialog is skipped this launch rather than stacking behind
+  /// it — `AppRatingManager` runs again naturally on a later launch.
+  Future<void> _showWhatsNewThenRating(BuildContext context) async {
+    final localStorage =
+        Provider.of<LocalStorageResource>(context, listen: false);
+    final manager = WhatsNewManager(localStorage: localStorage);
+    final shown = await manager.maybeShowPopup(context);
+    if (!mounted) return;
+    if (!shown) {
+      AppRatingManager(context);
+    }
   }
 
   @override

--- a/fivekmrun_app_flutter/lib/l10n/app_bg.arb
+++ b/fivekmrun_app_flutter/lib/l10n/app_bg.arb
@@ -208,5 +208,21 @@
   "barcode_page_wallet_error": "Грешка при добавяне в Wallet",
   "barcode_page_add_to_apple_wallet": "Добави в Apple Wallet",
   "add_offline_entry_page_invalid_run": "Невалидно бягане",
-  "add_offline_entry_page_invalid_run_message": "Моля изберете бягане от текущата седмица."
+  "add_offline_entry_page_invalid_run_message": "Моля изберете бягане от текущата седмица.",
+
+  "settings_page_whats_new": "Какво ново",
+  "settings_page_version": "Версия {version}",
+  "@settings_page_version": {
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "whats_new_page_title": "Какво ново",
+  "whats_new_page_current_version": "Текуща версия: {version}",
+  "@whats_new_page_current_version": {
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "whats_new_sheet_title": "Ново във версия {version}",
+  "@whats_new_sheet_title": {
+    "placeholders": { "version": { "type": "String" } }
+  },
+  "whats_new_sheet_dismiss": "Разбрах"
 }

--- a/fivekmrun_app_flutter/lib/l10n/app_en.arb
+++ b/fivekmrun_app_flutter/lib/l10n/app_en.arb
@@ -184,5 +184,12 @@
   "barcode_page_wallet_error": "Could not add the pass to Wallet",
   "barcode_page_add_to_apple_wallet": "Add to Apple Wallet",
   "add_offline_entry_page_invalid_run": "Invalid run",
-  "add_offline_entry_page_invalid_run_message": "Please choose a run from the current week."
+  "add_offline_entry_page_invalid_run_message": "Please choose a run from the current week.",
+
+  "settings_page_whats_new": "What's new",
+  "settings_page_version": "Version {version}",
+  "whats_new_page_title": "What's new",
+  "whats_new_page_current_version": "Current version: {version}",
+  "whats_new_sheet_title": "New in version {version}",
+  "whats_new_sheet_dismiss": "Got it"
 }

--- a/fivekmrun_app_flutter/lib/settings_page.dart
+++ b/fivekmrun_app_flutter/lib/settings_page.dart
@@ -2,8 +2,10 @@ import 'package:fivekmrun_flutter/push_notifications_manager.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
 import 'package:fivekmrun_flutter/state/local_storage_resource.dart';
 import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:fivekmrun_flutter/whats_new/whats_new_page.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'common/locale_switch.dart';
 import 'common/strava_connect.dart';
@@ -78,13 +80,37 @@ class _SettingsPageState extends State<SettingsPage> {
               ],
             ),
             Divider(color: dividerColor),
+            InkWell(
+              onTap: () => Navigator.of(context, rootNavigator: true)
+                  .push(MaterialPageRoute(builder: (_) => WhatsNewPage())),
+              child: Row(
+                children: <Widget>[
+                  Text(AppLocalizations.of(context)!.settings_page_whats_new),
+                  Spacer(),
+                  Icon(Icons.chevron_right),
+                ],
+              ),
+            ),
+            Divider(color: dividerColor),
             Row(children: <Widget>[
               Text(AppLocalizations.of(context)!.settings_page_exit),
               IconButton(
                 icon: const Icon(Icons.exit_to_app),
                 onPressed: logout,
               ),
-            ])
+            ]),
+            Divider(color: dividerColor),
+            FutureBuilder<PackageInfo>(
+              future: PackageInfo.fromPlatform(),
+              builder: (context, snapshot) {
+                if (!snapshot.hasData) return const SizedBox.shrink();
+                return Text(
+                  AppLocalizations.of(context)!
+                      .settings_page_version(snapshot.data!.version),
+                  style: Theme.of(context).textTheme.bodySmall,
+                );
+              },
+            ),
           ]),
         ));
   }

--- a/fivekmrun_app_flutter/lib/state/local_storage_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/local_storage_resource.dart
@@ -1,8 +1,10 @@
+import 'package:fivekmrun_flutter/constants.dart' as constants;
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class LocalStorageResource extends ChangeNotifier {
-  final String _keySubscribedForGeneral = "push_notifications_subscribed_general";
+  final String _keySubscribedForGeneral =
+      "push_notifications_subscribed_general";
 
   Future<SharedPreferences> _storage = SharedPreferences.getInstance();
 
@@ -12,6 +14,21 @@ class LocalStorageResource extends ChangeNotifier {
   }
 
   set isSubscrubedForGeneral(bool value) {
-    _storage.then((storage) => storage.setBool(this._keySubscribedForGeneral, value));
+    _storage.then(
+        (storage) => storage.setBool(this._keySubscribedForGeneral, value));
+  }
+
+  /// Null on a fresh install: nothing has been acknowledged yet.
+  Future<String?> get lastSeenWhatsNewVersion async {
+    final SharedPreferences storage = await _storage;
+    return storage.getString(constants.key_lastSeenWhatsNewVersion);
+  }
+
+  /// Awaited (unlike [isSubscrubedForGeneral]'s fire-and-forget setter) so
+  /// callers can rely on the write landing before deciding whether to show
+  /// the what's-new popup again on a following launch.
+  Future<void> setLastSeenWhatsNewVersion(String version) async {
+    final storage = await _storage;
+    await storage.setString(constants.key_lastSeenWhatsNewVersion, version);
   }
 }

--- a/fivekmrun_app_flutter/lib/state/whats_new_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/whats_new_resource.dart
@@ -1,0 +1,87 @@
+import 'dart:convert';
+
+import 'package:collection/collection.dart';
+import 'package:flutter/services.dart' show AssetBundle, rootBundle;
+
+/// A semver-ish `MAJOR.MINOR.PATCH` version, compared numerically rather than
+/// as a string — "3.9.0" must sort below "3.18.0", which a string compare
+/// gets wrong. Missing segments (e.g. a tag like "3.13") default to 0.
+class SemVer implements Comparable<SemVer> {
+  final int major;
+  final int minor;
+  final int patch;
+
+  const SemVer(this.major, this.minor, this.patch);
+
+  factory SemVer.parse(String version) {
+    final parts = version.split('.');
+    int segment(int index) =>
+        index < parts.length ? (int.tryParse(parts[index]) ?? 0) : 0;
+    return SemVer(segment(0), segment(1), segment(2));
+  }
+
+  @override
+  int compareTo(SemVer other) {
+    if (major != other.major) return major.compareTo(other.major);
+    if (minor != other.minor) return minor.compareTo(other.minor);
+    return patch.compareTo(other.patch);
+  }
+}
+
+/// One version's worth of highlight bullets, keyed by locale code (`"bg"`,
+/// `"en"`).
+class WhatsNewEntry {
+  final String version;
+  final Map<String, List<String>> bulletsByLocale;
+
+  WhatsNewEntry({required this.version, required this.bulletsByLocale});
+
+  /// Falls back to Bulgarian when the active locale has no bullets — bg is
+  /// the primary language for 5kmRun's audience.
+  List<String> bulletsFor(String localeCode) =>
+      bulletsByLocale[localeCode] ?? bulletsByLocale['bg'] ?? const [];
+}
+
+/// Loads and resolves the bundled `assets/whats_new.json` release-highlights
+/// archive.
+///
+/// Only significant, user-facing releases get an entry — patch and
+/// tech-only releases are simply absent, by design (see `/release`).
+class WhatsNewResource {
+  List<WhatsNewEntry> _entries = const [];
+
+  /// Newest first.
+  List<WhatsNewEntry> get entries => _entries;
+
+  /// Never throws: a missing or malformed asset must not crash startup, so a
+  /// parse failure just leaves [entries] empty and the popup/screen skip
+  /// silently.
+  Future<void> load({AssetBundle? bundle}) async {
+    try {
+      final raw =
+          await (bundle ?? rootBundle).loadString('assets/whats_new.json');
+      final Map<String, dynamic> json = jsonDecode(raw);
+
+      final versions = json.keys.toList()
+        ..sort((a, b) => SemVer.parse(b).compareTo(SemVer.parse(a)));
+
+      _entries = versions.map((version) {
+        final Map<String, dynamic> localeMap = json[version];
+        return WhatsNewEntry(
+          version: version,
+          bulletsByLocale: localeMap.map((locale, bullets) =>
+              MapEntry(locale, List<String>.from(bullets))),
+        );
+      }).toList();
+    } catch (_) {
+      _entries = const [];
+    }
+  }
+
+  WhatsNewEntry? entryFor(String version) =>
+      _entries.firstWhereOrNull((e) => e.version == version);
+
+  /// The history screen shows only the last three versions, per product
+  /// decision — the archive otherwise grows unbounded release over release.
+  List<WhatsNewEntry> get recentEntries => _entries.take(3).toList();
+}

--- a/fivekmrun_app_flutter/lib/whats_new/whats_new_manager.dart
+++ b/fivekmrun_app_flutter/lib/whats_new/whats_new_manager.dart
@@ -1,0 +1,76 @@
+import 'package:fivekmrun_flutter/state/local_storage_resource.dart';
+import 'package:fivekmrun_flutter/state/whats_new_resource.dart';
+import 'package:fivekmrun_flutter/whats_new/whats_new_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Decides whether to show the "what's new" popup on this launch, and shows
+/// it if so. Hooked into `home.dart`'s `afterFirstLayout`, ahead of
+/// [AppRatingManager] — see the caller for how the two are sequenced so they
+/// never appear at once.
+class WhatsNewManager {
+  /// Null unless injected for a test — production always builds and loads
+  /// its own, but a test needs to control what the asset resolves to, and
+  /// re-loading it here (with the real asset bundle) would clobber that.
+  final WhatsNewResource? _resource;
+  final Future<PackageInfo> Function() _packageInfoProvider;
+  final LocalStorageResource _localStorage;
+
+  WhatsNewManager({
+    required LocalStorageResource localStorage,
+    WhatsNewResource? resource,
+    Future<PackageInfo> Function()? packageInfoProvider,
+  })  : _localStorage = localStorage,
+        _resource = resource,
+        _packageInfoProvider = packageInfoProvider ?? PackageInfo.fromPlatform;
+
+  /// Returns whether the popup was shown, so the caller can skip the rating
+  /// prompt this launch rather than stacking it behind this one.
+  Future<bool> maybeShowPopup(BuildContext context) async {
+    final currentVersion = (await _packageInfoProvider()).version;
+    final storedVersion = await _localStorage.lastSeenWhatsNewVersion;
+
+    if (storedVersion == null) {
+      // Fresh install: nothing is "new" to a first-time user.
+      await _localStorage.setLastSeenWhatsNewVersion(currentVersion);
+      return false;
+    }
+
+    final current = SemVer.parse(currentVersion);
+    final stored = SemVer.parse(storedVersion);
+
+    // Same version relaunch, or a downgrade/debug build — never show.
+    if (current.compareTo(stored) <= 0) {
+      return false;
+    }
+
+    final resource = _resource ?? WhatsNewResource();
+    if (_resource == null) {
+      await resource.load();
+    }
+    final entry = resource.entryFor(currentVersion);
+
+    // Advance the stored version regardless of whether this version has an
+    // entry, so a patch/tech-only release doesn't leave the user stuck being
+    // prompted once a later version does have one.
+    await _localStorage.setLastSeenWhatsNewVersion(currentVersion);
+
+    if (entry == null) return false;
+    if (!context.mounted) return false;
+
+    final localeCode = Localizations.localeOf(context).languageCode;
+    // Not awaited: the sheet's own future only resolves once the user
+    // dismisses it, and this method's caller (afterFirstLayout) just needs
+    // to know the popup was shown, not wait for it to close.
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) => WhatsNewSheet(
+        version: currentVersion,
+        bullets: entry.bulletsFor(localeCode),
+      ),
+    );
+
+    return true;
+  }
+}

--- a/fivekmrun_app_flutter/lib/whats_new/whats_new_page.dart
+++ b/fivekmrun_app_flutter/lib/whats_new/whats_new_page.dart
@@ -1,0 +1,101 @@
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:fivekmrun_flutter/state/whats_new_resource.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart' show AssetBundle;
+import 'package:package_info_plus/package_info_plus.dart';
+
+/// Lists the last few versions' highlights, newest first, reachable from
+/// Settings. Reacts to a locale switch while open because [build] re-reads
+/// `Localizations.localeOf(context)` on every rebuild rather than caching it.
+class WhatsNewPage extends StatefulWidget {
+  /// Injectable for tests; defaults to a real resource in production.
+  final WhatsNewResource resource;
+  final Future<PackageInfo> Function() packageInfoProvider;
+
+  /// Test-only seam for [resource]'s asset load — production always reads
+  /// the real bundled asset.
+  final AssetBundle? bundle;
+
+  WhatsNewPage({
+    Key? key,
+    WhatsNewResource? resource,
+    Future<PackageInfo> Function()? packageInfoProvider,
+    this.bundle,
+  })  : resource = resource ?? WhatsNewResource(),
+        packageInfoProvider = packageInfoProvider ?? PackageInfo.fromPlatform,
+        super(key: key);
+
+  @override
+  _WhatsNewPageState createState() => _WhatsNewPageState();
+}
+
+class _WhatsNewPageState extends State<WhatsNewPage> {
+  bool _loading = true;
+  String? _currentVersion;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final results = await Future.wait(<Future<dynamic>>[
+      widget.resource.load(bundle: widget.bundle),
+      widget.packageInfoProvider(),
+    ]);
+    if (!mounted) return;
+    setState(() {
+      _currentVersion = (results[1] as PackageInfo).version;
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final localeCode = Localizations.localeOf(context).languageCode;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(color: Colors.white),
+        title: Text(l10n.whats_new_page_title),
+        centerTitle: true,
+      ),
+      body: _loading
+          ? Center(child: CircularProgressIndicator())
+          : ListView(
+              padding: const EdgeInsets.all(16.0),
+              children: <Widget>[
+                if (_currentVersion != null)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16.0),
+                    child: Text(
+                      l10n.whats_new_page_current_version(_currentVersion!),
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
+                  ),
+                for (final entry in widget.resource.recentEntries)
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 24.0),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        Text(
+                          entry.version,
+                          style: Theme.of(context).textTheme.titleLarge,
+                        ),
+                        const SizedBox(height: 8),
+                        for (final bullet in entry.bulletsFor(localeCode))
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 4.0),
+                            child: Text("• $bullet"),
+                          ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+    );
+  }
+}

--- a/fivekmrun_app_flutter/lib/whats_new/whats_new_sheet.dart
+++ b/fivekmrun_app_flutter/lib/whats_new/whats_new_sheet.dart
@@ -1,0 +1,47 @@
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+/// Bottom sheet shown once after an update, listing only the new version's
+/// highlights — a dialog would match the existing rating prompt, but a sheet
+/// handles longer bullet lists more gracefully (product decision on #199).
+class WhatsNewSheet extends StatelessWidget {
+  final String version;
+  final List<String> bullets;
+
+  const WhatsNewSheet({Key? key, required this.version, required this.bullets})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            Text(
+              l10n.whats_new_sheet_title(version),
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 16),
+            for (final bullet in bullets)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 8.0),
+                child: Text("• $bullet"),
+              ),
+            const SizedBox(height: 8),
+            Align(
+              alignment: Alignment.centerRight,
+              child: TextButton(
+                onPressed: () => Navigator.of(context).pop(),
+                child: Text(l10n.whats_new_sheet_dismiss),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/fivekmrun_app_flutter/pubspec.lock
+++ b/fivekmrun_app_flutter/pubspec.lock
@@ -838,7 +838,7 @@ packages:
     source: hosted
     version: "2.2.0"
   package_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: package_info_plus
       sha256: "4bf625947f6c7713ee242296a682e23e44823c09cf9d79e4f1238923c92db852"

--- a/fivekmrun_app_flutter/pubspec.yaml
+++ b/fivekmrun_app_flutter/pubspec.yaml
@@ -70,6 +70,7 @@ dependencies:
   app_badge_plus: ^1.2.3
   mobile_scanner: ^7.1.3
   audioplayers: ^6.6.0
+  package_info_plus: ^10.1.0
 
   flutter_localizations:
     sdk: flutter

--- a/fivekmrun_app_flutter/test/whats_new/whats_new_manager_test.dart
+++ b/fivekmrun_app_flutter/test/whats_new/whats_new_manager_test.dart
@@ -1,0 +1,187 @@
+import 'package:fivekmrun_flutter/constants.dart' as constants;
+import 'package:fivekmrun_flutter/state/local_storage_resource.dart';
+import 'package:fivekmrun_flutter/state/whats_new_resource.dart';
+import 'package:fivekmrun_flutter/whats_new/whats_new_manager.dart';
+import 'package:fivekmrun_flutter/whats_new/whats_new_sheet.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../localized_app.dart';
+
+class _FakeAssetBundle extends CachingAssetBundle {
+  final String _content;
+  _FakeAssetBundle(this._content);
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => _content;
+
+  @override
+  Future<ByteData> load(String key) async => throw UnimplementedError();
+}
+
+PackageInfo _packageInfo(String version) => PackageInfo(
+      appName: '5kmRun',
+      packageName: 'bg.fivekmpark.fivekmrun',
+      version: version,
+      buildNumber: '1',
+    );
+
+Future<WhatsNewResource> _loadedResource(String assetJson) async {
+  final resource = WhatsNewResource();
+  await resource.load(bundle: _FakeAssetBundle(assetJson));
+  return resource;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  const entryJson = '{"3.18.0": {"bg": ["ново"], "en": ["new stuff"]}}';
+
+  Future<BuildContext> pumpContext(WidgetTester tester) async {
+    late BuildContext captured;
+    await tester.pumpWidget(localizedApp(Builder(builder: (context) {
+      captured = context;
+      return const SizedBox();
+    })));
+    return captured;
+  }
+
+  testWidgets('fresh install: no popup, stores the current version',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    final context = await pumpContext(tester);
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource(entryJson),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    );
+
+    final shown = await manager.maybeShowPopup(context);
+    await tester.pumpAndSettle();
+
+    expect(shown, isFalse);
+    expect(find.byType(WhatsNewSheet), findsNothing);
+    expect(await LocalStorageResource().lastSeenWhatsNewVersion, '3.18.0');
+  });
+
+  testWidgets('same-version relaunch: no popup', (tester) async {
+    SharedPreferences.setMockInitialValues(
+        {constants.key_lastSeenWhatsNewVersion: '3.18.0'});
+    final context = await pumpContext(tester);
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource(entryJson),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    );
+
+    final shown = await manager.maybeShowPopup(context);
+    await tester.pumpAndSettle();
+
+    expect(shown, isFalse);
+    expect(find.byType(WhatsNewSheet), findsNothing);
+  });
+
+  testWidgets('downgrade / debug build: no popup', (tester) async {
+    SharedPreferences.setMockInitialValues(
+        {constants.key_lastSeenWhatsNewVersion: '3.18.0'});
+    final context = await pumpContext(tester);
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource(entryJson),
+      packageInfoProvider: () async => _packageInfo('3.9.0'),
+    );
+
+    final shown = await manager.maybeShowPopup(context);
+    await tester.pumpAndSettle();
+
+    expect(shown, isFalse);
+  });
+
+  testWidgets(
+      'upgrade to a version with no archive entry: no popup, version still advances',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(
+        {constants.key_lastSeenWhatsNewVersion: '3.18.0'});
+    final context = await pumpContext(tester);
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource(entryJson),
+      packageInfoProvider: () async => _packageInfo('3.18.1'),
+    );
+
+    final shown = await manager.maybeShowPopup(context);
+    await tester.pumpAndSettle();
+
+    expect(shown, isFalse);
+    expect(find.byType(WhatsNewSheet), findsNothing);
+    expect(await LocalStorageResource().lastSeenWhatsNewVersion, '3.18.1');
+  });
+
+  testWidgets(
+      'upgrade with an entry shows the sheet and advances the stored version',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(
+        {constants.key_lastSeenWhatsNewVersion: '3.9.0'});
+    final context = await pumpContext(tester);
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource(entryJson),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    );
+
+    final shown = await manager.maybeShowPopup(context);
+    await tester.pumpAndSettle();
+
+    expect(shown, isTrue);
+    expect(find.byType(WhatsNewSheet), findsOneWidget);
+    expect(find.text('• ново'), findsOneWidget);
+    expect(await LocalStorageResource().lastSeenWhatsNewVersion, '3.18.0');
+  });
+
+  testWidgets('semver comparison treats 3.9.0 as older than 3.18.0, not newer',
+      (tester) async {
+    // A naive string compare puts "3.9.0" after "3.18.0" and would suppress
+    // this upgrade's popup.
+    SharedPreferences.setMockInitialValues(
+        {constants.key_lastSeenWhatsNewVersion: '3.9.0'});
+    final context = await pumpContext(tester);
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource(entryJson),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    );
+
+    final shown = await manager.maybeShowPopup(context);
+    await tester.pumpAndSettle();
+
+    expect(shown, isTrue);
+  });
+
+  testWidgets('falls back to bg when the active locale has no bullets',
+      (tester) async {
+    SharedPreferences.setMockInitialValues(
+        {constants.key_lastSeenWhatsNewVersion: '3.9.0'});
+    late BuildContext captured;
+    await tester.pumpWidget(localizedApp(
+      Builder(builder: (context) {
+        captured = context;
+        return const SizedBox();
+      }),
+      locale: const Locale('en'),
+    ));
+    final manager = WhatsNewManager(
+      localStorage: LocalStorageResource(),
+      resource: await _loadedResource('{"3.18.0": {"bg": ["само бг"]}}'),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    );
+
+    final shown = await manager.maybeShowPopup(captured);
+    await tester.pumpAndSettle();
+
+    expect(shown, isTrue);
+    expect(find.text('• само бг'), findsOneWidget);
+  });
+}

--- a/fivekmrun_app_flutter/test/whats_new/whats_new_page_test.dart
+++ b/fivekmrun_app_flutter/test/whats_new/whats_new_page_test.dart
@@ -1,0 +1,97 @@
+import 'package:fivekmrun_flutter/state/whats_new_resource.dart';
+import 'package:fivekmrun_flutter/whats_new/whats_new_page.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../localized_app.dart';
+
+class _FakeAssetBundle extends CachingAssetBundle {
+  final String _content;
+  _FakeAssetBundle(this._content);
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async => _content;
+
+  @override
+  Future<ByteData> load(String key) async => throw UnimplementedError();
+}
+
+PackageInfo _packageInfo(String version) => PackageInfo(
+      appName: '5kmRun',
+      packageName: 'bg.fivekmpark.fivekmrun',
+      version: version,
+      buildNumber: '1',
+    );
+
+void main() {
+  const assetJson = '''
+  {
+    "3.18.0": {"bg": ["ново в 18"], "en": ["new in 18"]},
+    "3.17.0": {"bg": ["ново в 17"], "en": ["new in 17"]},
+    "2.0.0": {"bg": ["ново в 2"], "en": ["new in 2"]},
+    "1.0.0": {"bg": ["ново в 1"], "en": ["new in 1"]}
+  }
+  ''';
+
+  testWidgets('lists versions newest-first, capped at the last three',
+      (tester) async {
+    await tester.pumpWidget(localizedApp(WhatsNewPage(
+      bundle: _FakeAssetBundle(assetJson),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text('3.18.0'), findsOneWidget);
+    expect(find.text('3.17.0'), findsOneWidget);
+    expect(find.text('2.0.0'), findsOneWidget);
+    expect(find.text('1.0.0'), findsNothing);
+
+    final versionTexts = tester
+        .widgetList<Text>(find.byType(Text))
+        .map((t) => t.data)
+        .whereType<String>()
+        .where((s) => s == '3.18.0' || s == '3.17.0' || s == '2.0.0')
+        .toList();
+    expect(versionTexts, ['3.18.0', '3.17.0', '2.0.0']);
+  });
+
+  testWidgets('shows the running app version', (tester) async {
+    await tester.pumpWidget(localizedApp(WhatsNewPage(
+      bundle: _FakeAssetBundle(assetJson),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    )));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Текуща версия: 3.18.0'), findsOneWidget);
+  });
+
+  testWidgets('shows the English bullets when the locale is English',
+      (tester) async {
+    await tester.pumpWidget(localizedApp(
+      WhatsNewPage(
+        bundle: _FakeAssetBundle(assetJson),
+        packageInfoProvider: () async => _packageInfo('3.18.0'),
+      ),
+      locale: const Locale('en'),
+    ));
+    await tester.pumpAndSettle();
+
+    expect(find.text('• new in 18'), findsOneWidget);
+    expect(find.text('• ново в 18'), findsNothing);
+  });
+
+  testWidgets('a malformed asset renders an empty list instead of crashing',
+      (tester) async {
+    await tester.pumpWidget(localizedApp(WhatsNewPage(
+      resource: WhatsNewResource(),
+      bundle: _FakeAssetBundle('not json'),
+      packageInfoProvider: () async => _packageInfo('3.18.0'),
+    )));
+    await tester.pumpAndSettle();
+
+    expect(tester.takeException(), isNull);
+    expect(find.text('3.18.0'), findsNothing);
+  });
+}

--- a/fivekmrun_app_flutter/test/whats_new/whats_new_resource_test.dart
+++ b/fivekmrun_app_flutter/test/whats_new/whats_new_resource_test.dart
@@ -1,0 +1,101 @@
+import 'package:fivekmrun_flutter/state/whats_new_resource.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+class _FakeAssetBundle extends CachingAssetBundle {
+  final String? _content;
+
+  _FakeAssetBundle(this._content);
+
+  @override
+  Future<String> loadString(String key, {bool cache = true}) async {
+    final content = _content;
+    if (content == null) throw Exception('asset not found: $key');
+    return content;
+  }
+
+  @override
+  Future<ByteData> load(String key) async {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  group('SemVer', () {
+    test('compares numerically, not lexicographically', () {
+      expect(
+          SemVer.parse('3.9.0').compareTo(SemVer.parse('3.18.0')), lessThan(0));
+      expect(SemVer.parse('3.18.0').compareTo(SemVer.parse('3.9.0')),
+          greaterThan(0));
+    });
+
+    test('treats missing segments as zero', () {
+      expect(SemVer.parse('3.13').compareTo(SemVer.parse('3.13.0')), 0);
+    });
+
+    test('equal versions compare as 0', () {
+      expect(SemVer.parse('3.18.0').compareTo(SemVer.parse('3.18.0')), 0);
+    });
+  });
+
+  group('WhatsNewResource.load', () {
+    test('parses entries newest-first by semver, not string order', () async {
+      final resource = WhatsNewResource();
+      await resource.load(bundle: _FakeAssetBundle('''
+      {
+        "3.9.0": {"bg": ["old"], "en": ["old"]},
+        "3.18.0": {"bg": ["new"], "en": ["new"]}
+      }
+      '''));
+
+      expect(resource.entries.map((e) => e.version), ['3.18.0', '3.9.0']);
+    });
+
+    test('bulletsFor falls back to bg when the locale is missing', () async {
+      final resource = WhatsNewResource();
+      await resource.load(
+          bundle: _FakeAssetBundle('{"3.18.0": {"bg": ["само бг"]}}'));
+
+      final entry = resource.entryFor('3.18.0')!;
+      expect(entry.bulletsFor('en'), ['само бг']);
+      expect(entry.bulletsFor('bg'), ['само бг']);
+    });
+
+    test('entryFor returns null for a version with no entry', () async {
+      final resource = WhatsNewResource();
+      await resource.load(
+          bundle: _FakeAssetBundle('{"3.18.0": {"bg": ["x"], "en": ["x"]}}'));
+
+      expect(resource.entryFor('3.19.1'), isNull);
+    });
+
+    test('recentEntries caps at the last three versions', () async {
+      final resource = WhatsNewResource();
+      await resource.load(bundle: _FakeAssetBundle('''
+      {
+        "1.0.0": {"bg": ["a"], "en": ["a"]},
+        "2.0.0": {"bg": ["b"], "en": ["b"]},
+        "3.0.0": {"bg": ["c"], "en": ["c"]},
+        "4.0.0": {"bg": ["d"], "en": ["d"]}
+      }
+      '''));
+
+      expect(resource.recentEntries.map((e) => e.version),
+          ['4.0.0', '3.0.0', '2.0.0']);
+    });
+
+    test('a missing asset leaves entries empty instead of throwing', () async {
+      final resource = WhatsNewResource();
+      await resource.load(bundle: _FakeAssetBundle(null));
+
+      expect(resource.entries, isEmpty);
+    });
+
+    test('malformed JSON leaves entries empty instead of throwing', () async {
+      final resource = WhatsNewResource();
+      await resource.load(bundle: _FakeAssetBundle('not json'));
+
+      expect(resource.entries, isEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements #199: release notes already get written every release (`whatsnew/whatsnew-bg`, `whatsnew/whatsnew-en-GB`) but never surfaced inside the app. This adds:
1. A **What's New screen**, reachable from Settings, listing the last 3 versions and their highlights.
2. An **automatic bottom-sheet popup** on first launch after an update, showing just the new version's highlights.

Per the issue's design decisions:
- Content lives in a bundled JSON archive (`assets/whats_new.json`), not the ARB files — a per-version key would bloat the ARBs with metadata that has nothing to do with translation.
- **New dependency added: `package_info_plus: ^10.1.0`** — explicitly approved by the maintainer in chat before adding (it was already a transitive dependency at the same version via another plugin, so this adds no new resolution). Used to read the running app version at runtime; also now shown in Settings.
- The popup takes precedence over the existing rating dialog (`AppRatingManager`) — when it's shown, the rating dialog is simply skipped this launch (not stacked behind it) and runs normally on a later launch, since neither manager corrupts the other's own launch-count bookkeeping.
- Suppressed on fresh install (no stored version → silently records current version, no popup).
- A version with no archive entry (patch/tech release) shows no popup but still advances the stored version, so the user isn't later prompted for a version they've long moved past.
- Version comparison is real semver (`SemVer`), not string comparison — `"3.9.0" < "3.18.0"` needs numeric comparison to get right.
- History screen caps at the last 3 versions per product decision in the issue.
- `/release`'s step 6 now also proposes What's New bullets and asks for confirmation before writing a new archive entry, explicitly skipping patch/tech-only releases.

## Changes
- `lib/state/whats_new_resource.dart` — `SemVer` (semver parse/compare) + `WhatsNewResource` (loads/parses `assets/whats_new.json`, resolves bullets per locale falling back to `bg`, never throws on a missing/malformed asset).
- `lib/whats_new/whats_new_manager.dart` — `WhatsNewManager.maybeShowPopup`: the fresh-install / same-version / downgrade / no-entry / has-entry decision tree described above.
- `lib/whats_new/whats_new_page.dart`, `lib/whats_new/whats_new_sheet.dart` — the screen and the popup's bottom sheet.
- `lib/state/local_storage_resource.dart` — new `lastSeenWhatsNewVersion` get/set, mirroring the existing device-level-flag pattern.
- `lib/settings_page.dart` — new "What's new" row + running app version footer.
- `lib/home.dart` — `afterFirstLayout` now checks the popup before `AppRatingManager`.
- `lib/constants.dart` — new `key_lastSeenWhatsNewVersion` SharedPreferences key.
- `lib/l10n/app_bg.arb` / `app_en.arb` — new UI chrome strings, kept in sync (arb parity test passes).
- `assets/whats_new.json` — seeded with `3.18.0` and `3.17.0`, taken directly from the existing `whatsnew/` files.
- `.claude/commands/release.md` — step 6 now also proposes/confirms What's New bullets and writes them to the archive, skipping patch/tech-only releases.
- `pubspec.yaml` / `pubspec.lock` — added `package_info_plus: ^10.1.0` as a direct dependency (was already transitive at this version).

## Test plan
- New tests: `test/whats_new/whats_new_resource_test.dart` (semver comparison/equality, newest-first ordering, locale fallback, missing-entry, recentEntries cap, malformed/missing asset doesn't throw), `test/whats_new/whats_new_manager_test.dart` (fresh install, same-version, downgrade, no-entry-but-advances, has-entry shows sheet, `3.9.0 → 3.18.0` semver correctness, locale fallback in the live popup), `test/whats_new/whats_new_page_test.dart` (newest-first + 3-version cap, current version s...
- `flutter analyze` (full project): 0 errors, 0 new warnings — the 6 pre-existing warnings are all in unrelated files (`barcode_page.dart`, `push_notifications_manager.dart`, `chronometer_view.dart`, `past_events_test.dart`).
- `flutter test` (full suite): all 242 tests pass, no regressions.
- Manually verified on a booted Android emulator (Pixel 7 API 36, real logged-in account): Settings shows the new "What's new" row and "Version 3.18.0" footer; tapping it opens the What's New screen showing "Current version: 3.18.0" and the seeded 3.18.0/3.17.0 bullets in English (device locale); app launches cleanly with the new `afterFirstLayout` hook — no crash. Didn't manually exercise the popup itself on-device (would require manipulating the stored-version SharedPreferences key to simul...

## Manual testing instructions
1. Settings → "What's new" → confirms the screen lists 3.18.0 and 3.17.0 with bullets, and shows the running app version at the top.
2. To see the popup: on a device that already has the app installed at an older version with an archive entry (e.g. simulate by setting the `5kmrun_LastSeenWhatsNewVersion` SharedPreferences key to `3.9.0` and relaunching on 3.18.0), a bottom sheet should appear once with that version's bullets, then never reappear on a same-version relaunch.

Closes #199