### PR TITLE
feat: manual barcode entry and correction on the timekeeping scanner

### DIFF
--- a/fivekmrun_app_flutter/lib/l10n/app_bg.arb
+++ b/fivekmrun_app_flutter/lib/l10n/app_bg.arb
@@ -204,6 +204,16 @@
   "@barcode_scanner_save_error": {
     "placeholders": { "error": { "type": "String" } }
   },
+  "barcode_scanner_add_manually": "Добави ръчно",
+  "barcode_scanner_manual_entry_badge": "Добавено/коригирано ръчно",
+
+  "manual_entry_dialog_title": "Ръчно въвеждане",
+  "manual_entry_dialog_runner_id_label": "Номер на участник",
+  "manual_entry_dialog_place_label": "Място",
+  "manual_entry_dialog_invalid_runner_id": "Въведете валиден номер на участник (до 10 цифри)",
+  "manual_entry_dialog_invalid_place": "Въведете валидно място",
+  "manual_entry_dialog_duplicate_runner_warning": "Този номер вече е записан",
+  "manual_entry_dialog_save": "Запази",
 
   "barcode_page_wallet_error": "Грешка при добавяне в Wallet",
   "barcode_page_add_to_apple_wallet": "Добави в Apple Wallet",

--- a/fivekmrun_app_flutter/lib/l10n/app_en.arb
+++ b/fivekmrun_app_flutter/lib/l10n/app_en.arb
@@ -180,6 +180,16 @@
   "barcode_scanner_place": "Place: {value}",
   "barcode_scanner_place_pending": "Place: (waiting for scan)",
   "barcode_scanner_save_error": "Error saving: {error}",
+  "barcode_scanner_add_manually": "Add manually",
+  "barcode_scanner_manual_entry_badge": "Manually added or edited",
+
+  "manual_entry_dialog_title": "Manual entry",
+  "manual_entry_dialog_runner_id_label": "Runner ID",
+  "manual_entry_dialog_place_label": "Place",
+  "manual_entry_dialog_invalid_runner_id": "Enter a valid runner ID (up to 10 digits)",
+  "manual_entry_dialog_invalid_place": "Enter a valid place",
+  "manual_entry_dialog_duplicate_runner_warning": "This runner ID is already recorded",
+  "manual_entry_dialog_save": "Save",
 
   "barcode_page_wallet_error": "Could not add the pass to Wallet",
   "barcode_page_add_to_apple_wallet": "Add to Apple Wallet",

--- a/fivekmrun_app_flutter/lib/timekeeping/barcode_scanner.dart
+++ b/fivekmrun_app_flutter/lib/timekeeping/barcode_scanner.dart
@@ -6,22 +6,26 @@ import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:audioplayers/audioplayers.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:fivekmrun_flutter/timekeeping/manual_entry_dialog.dart';
 import 'dart:convert';
 import 'dart:io';
 
 class ScannedBarcode {
   final String value;
   final DateTime timestamp;
+  final bool isManual;
 
   ScannedBarcode({
     required this.value,
     required this.timestamp,
+    this.isManual = false,
   });
 
   Map<String, dynamic> toJson() {
     return {
       'value': value,
       'timestamp': timestamp.toIso8601String(),
+      'isManual': isManual,
     };
   }
 
@@ -29,6 +33,9 @@ class ScannedBarcode {
     return ScannedBarcode(
       value: json['value'] as String,
       timestamp: DateTime.parse(json['timestamp'] as String),
+      // Missing in JSON saved by a previous app version — default false so
+      // an in-progress session survives the update.
+      isManual: json['isManual'] as bool? ?? false,
     );
   }
 }
@@ -241,6 +248,83 @@ class _BarcodeScannerState extends State<BarcodeScanner>
     }
   }
 
+  bool _isDuplicateRunnerId(String formattedRunnerId, {int? excludingIndex}) {
+    for (var i = 0; i < scannedValues.length; i += 2) {
+      if (i == excludingIndex) continue;
+      if (scannedValues[i].value == formattedRunnerId) return true;
+    }
+    return false;
+  }
+
+  /// Appends a manually-entered pair, or — if the last scan is a dangling
+  /// runner ID with no place yet — completes that pair instead of starting a
+  /// new one, so pair numbering stays correct.
+  Future<void> _addManually() async {
+    final bool completingDanglingPair = scannedValues.length.isOdd;
+    final String? initialRunnerId =
+        completingDanglingPair ? stripRunnerId(scannedValues.last.value) : null;
+
+    final result = await showDialog<ManualEntryResult>(
+      context: context,
+      builder: (context) => ManualEntryDialog(
+        initialRunnerIdDigits: initialRunnerId,
+        lockRunnerId: completingDanglingPair,
+        isDuplicateRunner: (id) => _isDuplicateRunnerId(id),
+      ),
+    );
+    if (result == null || !mounted) return;
+
+    final now = DateTime.now();
+    setState(() {
+      if (completingDanglingPair) {
+        scannedValues.add(ScannedBarcode(
+            value: result.place, timestamp: now, isManual: true));
+      } else {
+        scannedValues.add(ScannedBarcode(
+            value: result.runnerId!, timestamp: now, isManual: true));
+        scannedValues.add(ScannedBarcode(
+            value: result.place, timestamp: now, isManual: true));
+      }
+      // A stray camera re-detection of the same code right after a manual
+      // entry must not duplicate it.
+      lastScannedValue = scannedValues.last.value;
+    });
+    _saveState();
+  }
+
+  /// Opens the same dialog pre-filled with an existing pair's values so it
+  /// can be corrected in place. Keeps both entries' original timestamps —
+  /// only the values change — preserving chronology and export line order.
+  Future<void> _editPair(int firstIndex, int? secondIndex) async {
+    if (secondIndex == null) {
+      // Tapped the trailing dangling pair — complete it rather than editing
+      // a place entry that doesn't exist yet.
+      return _addManually();
+    }
+
+    final first = scannedValues[firstIndex];
+    final second = scannedValues[secondIndex];
+
+    final result = await showDialog<ManualEntryResult>(
+      context: context,
+      builder: (context) => ManualEntryDialog(
+        initialRunnerIdDigits: stripRunnerId(first.value),
+        initialPlaceDigits: stripPlace(second.value),
+        isDuplicateRunner: (id) =>
+            _isDuplicateRunnerId(id, excludingIndex: firstIndex),
+      ),
+    );
+    if (result == null || !mounted) return;
+
+    setState(() {
+      scannedValues[firstIndex] = ScannedBarcode(
+          value: result.runnerId!, timestamp: first.timestamp, isManual: true);
+      scannedValues[secondIndex] = ScannedBarcode(
+          value: result.place, timestamp: second.timestamp, isManual: true);
+    });
+    _saveState();
+  }
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -249,6 +333,11 @@ class _BarcodeScannerState extends State<BarcodeScanner>
         title: Text(l10n.timekeeping_scanning),
         centerTitle: true,
         actions: [
+          IconButton(
+            icon: const Icon(Icons.edit_note),
+            onPressed: _addManually,
+            tooltip: l10n.barcode_scanner_add_manually,
+          ),
           IconButton(
             key: _saveButtonKey,
             icon: const Icon(Icons.save_alt),
@@ -392,6 +481,11 @@ class _BarcodeScannerState extends State<BarcodeScanner>
                           return shouldDelete;
                         },
                         child: ListTile(
+                          onTap: () => _editPair(
+                              firstIndex,
+                              secondIndex < scannedValues.length
+                                  ? secondIndex
+                                  : null),
                           leading: CircleAvatar(
                               child: Text('${_getPairCount() - index}')),
                           title: Text(
@@ -414,6 +508,14 @@ class _BarcodeScannerState extends State<BarcodeScanner>
                                   : FontWeight.normal,
                             ),
                           ),
+                          trailing: (first.isManual ||
+                                  (second?.isManual ?? false))
+                              ? Tooltip(
+                                  message:
+                                      l10n.barcode_scanner_manual_entry_badge,
+                                  child: const Icon(Icons.edit, size: 18),
+                                )
+                              : null,
                         ),
                       );
                     },

--- a/fivekmrun_app_flutter/lib/timekeeping/manual_entry_dialog.dart
+++ b/fivekmrun_app_flutter/lib/timekeeping/manual_entry_dialog.dart
@@ -1,0 +1,182 @@
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:flutter/material.dart';
+
+/// Digits the marshal types -> the zero-padded 10-digit barcode format used
+/// everywhere else in the app (see `formatBarcode` in barcode_page.dart).
+/// Returns null when the input can't be a valid runner ID.
+String? formatRunnerId(String input) {
+  final digits = input.trim();
+  if (digits.isEmpty) return null;
+  if (!RegExp(r'^\d+$').hasMatch(digits)) return null;
+  if (digits.length > 10) return null;
+  return digits.padLeft(10, '0');
+}
+
+/// Digits the marshal types -> the "J"-prefixed form real place tokens use.
+/// The marshal types the digits already at the width the physical tokens use
+/// (e.g. "001"), so this only adds the prefix.
+String? formatPlace(String input) {
+  final digits = input.trim();
+  if (digits.isEmpty) return null;
+  if (!RegExp(r'^\d+$').hasMatch(digits)) return null;
+  return 'J$digits';
+}
+
+/// Strips a stored runner-ID barcode's zero-padding back to the digits a
+/// marshal would type — used to prefill the dialog when editing.
+String stripRunnerId(String storedValue) =>
+    storedValue.replaceFirst(RegExp(r'^0+(?=\d)'), '');
+
+/// Strips a stored place token's "J" prefix back to the digits a marshal
+/// would type — used to prefill the dialog when editing.
+String stripPlace(String storedValue) => storedValue.substring(1);
+
+/// The dialog's outcome. [runnerId] is null when the runner ID field was
+/// locked (completing a dangling pair) — the caller already knows it.
+class ManualEntryResult {
+  final String? runnerId;
+  final String place;
+
+  const ManualEntryResult({this.runnerId, required this.place});
+}
+
+/// Collects a runner ID + place pair for manual entry or correction.
+///
+/// Used in three modes, distinguished by the constructor params:
+///  - fresh add: both fields empty and editable.
+///  - completing a dangling pair (an odd-length scanned list): runner ID is
+///    pre-filled and locked, only the place is collected.
+///  - editing an existing pair: both fields pre-filled and editable.
+class ManualEntryDialog extends StatefulWidget {
+  final String? initialRunnerIdDigits;
+  final String? initialPlaceDigits;
+  final bool lockRunnerId;
+
+  /// Checked against the live runner-ID field value to show a non-blocking
+  /// duplicate warning — the caller decides what counts as a duplicate (e.g.
+  /// excluding the pair currently being edited).
+  final bool Function(String formattedRunnerId) isDuplicateRunner;
+
+  const ManualEntryDialog({
+    Key? key,
+    this.initialRunnerIdDigits,
+    this.initialPlaceDigits,
+    this.lockRunnerId = false,
+    required this.isDuplicateRunner,
+  }) : super(key: key);
+
+  @override
+  State<ManualEntryDialog> createState() => _ManualEntryDialogState();
+}
+
+class _ManualEntryDialogState extends State<ManualEntryDialog> {
+  late final TextEditingController _runnerIdController;
+  late final TextEditingController _placeController;
+  String? _runnerIdError;
+  String? _placeError;
+
+  @override
+  void initState() {
+    super.initState();
+    _runnerIdController =
+        TextEditingController(text: widget.initialRunnerIdDigits ?? '');
+    _placeController =
+        TextEditingController(text: widget.initialPlaceDigits ?? '');
+    _runnerIdController.addListener(() => setState(() {}));
+    _placeController.addListener(() => setState(() {}));
+  }
+
+  @override
+  void dispose() {
+    _runnerIdController.dispose();
+    _placeController.dispose();
+    super.dispose();
+  }
+
+  String? get _previewRunnerId => widget.lockRunnerId
+      ? widget.initialRunnerIdDigits == null
+          ? null
+          : formatRunnerId(widget.initialRunnerIdDigits!)
+      : formatRunnerId(_runnerIdController.text);
+
+  String? get _previewPlace => formatPlace(_placeController.text);
+
+  void _submit() {
+    final l10n = AppLocalizations.of(context)!;
+    final runnerId = _previewRunnerId;
+    final place = _previewPlace;
+
+    setState(() {
+      _runnerIdError = (!widget.lockRunnerId && runnerId == null)
+          ? l10n.manual_entry_dialog_invalid_runner_id
+          : null;
+      _placeError =
+          place == null ? l10n.manual_entry_dialog_invalid_place : null;
+    });
+
+    if (runnerId == null || place == null) return;
+
+    Navigator.of(context).pop(ManualEntryResult(
+      runnerId: widget.lockRunnerId ? null : runnerId,
+      place: place,
+    ));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final previewRunnerId = _previewRunnerId;
+    final isDuplicate =
+        previewRunnerId != null && widget.isDuplicateRunner(previewRunnerId);
+
+    return AlertDialog(
+      title: Text(l10n.manual_entry_dialog_title),
+      content: SingleChildScrollView(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: <Widget>[
+            TextField(
+              controller: _runnerIdController,
+              enabled: !widget.lockRunnerId,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: l10n.manual_entry_dialog_runner_id_label,
+                errorText: _runnerIdError,
+                helperText: previewRunnerId,
+              ),
+            ),
+            if (isDuplicate)
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0),
+                child: Text(
+                  l10n.manual_entry_dialog_duplicate_runner_warning,
+                  style: const TextStyle(color: Colors.orange),
+                ),
+              ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _placeController,
+              keyboardType: TextInputType.number,
+              decoration: InputDecoration(
+                labelText: l10n.manual_entry_dialog_place_label,
+                errorText: _placeError,
+                helperText: _previewPlace,
+              ),
+            ),
+          ],
+        ),
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(),
+          child: Text(l10n.cancel),
+        ),
+        TextButton(
+          onPressed: _submit,
+          child: Text(l10n.manual_entry_dialog_save),
+        ),
+      ],
+    );
+  }
+}

--- a/fivekmrun_app_flutter/test/timekeeping/barcode_scanner_test.dart
+++ b/fivekmrun_app_flutter/test/timekeeping/barcode_scanner_test.dart
@@ -1,0 +1,213 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/timekeeping/barcode_scanner.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../localized_app.dart';
+
+Future<void> pumpScanner(WidgetTester tester) async {
+  await tester.pumpWidget(
+      localizedApp(const BarcodeScanner(), locale: const Locale('en')));
+  // Lets _loadSavedState's SharedPreferences read land before interacting.
+  await tester.pump(const Duration(milliseconds: 100));
+}
+
+Future<List<Map<String, dynamic>>> savedValues() async {
+  final prefs = await SharedPreferences.getInstance();
+  final json = prefs.getString('barcode_scanner_values');
+  if (json == null) return [];
+  return (jsonDecode(json) as List).cast<Map<String, dynamic>>();
+}
+
+void main() {
+  testWidgets('manual add appends a valid pair to an empty list',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await pumpScanner(tester);
+
+    await tester.tap(find.byTooltip('Add manually'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    await tester.enterText(find.byType(TextField).at(0), '12345');
+    await tester.enterText(find.byType(TextField).at(1), '017');
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.textContaining('0000012345'), findsOneWidget);
+    expect(find.textContaining('J017'), findsOneWidget);
+
+    final saved = await savedValues();
+    expect(saved, hasLength(2));
+    expect(saved[0]['value'], '0000012345');
+    expect(saved[0]['isManual'], isTrue);
+    expect(saved[1]['value'], 'J017');
+    expect(saved[1]['isManual'], isTrue);
+  });
+
+  testWidgets('invalid input is rejected without mutating the list',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({});
+    await pumpScanner(tester);
+
+    await tester.tap(find.byTooltip('Add manually'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // Both fields left empty.
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(
+        find.text('Enter a valid runner ID (up to 10 digits)'), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.text('Scan a barcode'), findsOneWidget);
+    expect(await savedValues(), isEmpty);
+  });
+
+  testWidgets(
+      'an odd-length list completes the dangling pair instead of '
+      'appending a new one', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'barcode_scanner_values': jsonEncode([
+        ScannedBarcode(value: '0000012345', timestamp: DateTime(2026, 1, 1))
+            .toJson(),
+      ]),
+    });
+    await pumpScanner(tester);
+
+    await tester.tap(find.byTooltip('Add manually'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    // The runner ID field is locked and pre-filled — only the place is
+    // editable to complete the pair.
+    final runnerIdField =
+        tester.widget<TextField>(find.byType(TextField).at(0));
+    expect(runnerIdField.enabled, isFalse);
+    expect(runnerIdField.controller!.text, '12345');
+
+    await tester.enterText(find.byType(TextField).at(1), '099');
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final saved = await savedValues();
+    expect(saved, hasLength(2)); // completed, not a fresh 3rd/4th entry
+    expect(saved[0]['value'], '0000012345');
+    expect(saved[1]['value'], 'J099');
+    expect(saved[1]['isManual'], isTrue);
+    expect(find.textContaining('J099'), findsOneWidget);
+  });
+
+  testWidgets(
+      'editing an existing pair updates values in place and '
+      'preserves the original timestamps', (tester) async {
+    final runnerTimestamp = DateTime(2026, 1, 1, 10, 0);
+    final placeTimestamp = DateTime(2026, 1, 1, 10, 5);
+    SharedPreferences.setMockInitialValues({
+      'barcode_scanner_values': jsonEncode([
+        ScannedBarcode(value: '0000012345', timestamp: runnerTimestamp)
+            .toJson(),
+        ScannedBarcode(value: 'J001', timestamp: placeTimestamp).toJson(),
+      ]),
+    });
+    await pumpScanner(tester);
+
+    await tester.tap(find.byType(ListTile).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final runnerIdField =
+        tester.widget<TextField>(find.byType(TextField).at(0));
+    final placeField = tester.widget<TextField>(find.byType(TextField).at(1));
+    expect(runnerIdField.enabled, isTrue);
+    expect(runnerIdField.controller!.text, '12345');
+    expect(placeField.controller!.text, '001');
+
+    await tester.enterText(find.byType(TextField).at(0), '99999');
+    await tester.enterText(find.byType(TextField).at(1), '005');
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final saved = await savedValues();
+    expect(saved, hasLength(2));
+    expect(saved[0]['value'], '0000099999');
+    expect(saved[0]['timestamp'], runnerTimestamp.toIso8601String());
+    expect(saved[0]['isManual'], isTrue);
+    expect(saved[1]['value'], 'J005');
+    expect(saved[1]['timestamp'], placeTimestamp.toIso8601String());
+    expect(saved[1]['isManual'], isTrue);
+  });
+
+  testWidgets('manually added or edited rows are marked with a badge icon',
+      (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'barcode_scanner_values': jsonEncode([
+        ScannedBarcode(value: '0000012345', timestamp: DateTime(2026, 1, 1))
+            .toJson(),
+        ScannedBarcode(value: 'J001', timestamp: DateTime(2026, 1, 1)).toJson(),
+      ]),
+    });
+    await pumpScanner(tester);
+
+    expect(find.byIcon(Icons.edit), findsNothing);
+
+    await tester.tap(find.byType(ListTile).first);
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('Save')); // unchanged values still validate
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    expect(find.byIcon(Icons.edit), findsOneWidget);
+  });
+
+  testWidgets(
+      'swipe-to-delete still removes a manually added pair, and pair '
+      'numbering stays correct afterwards', (tester) async {
+    SharedPreferences.setMockInitialValues({
+      'barcode_scanner_values': jsonEncode([
+        ScannedBarcode(
+                value: '0000011111',
+                timestamp: DateTime(2026, 1, 1),
+                isManual: true)
+            .toJson(),
+        ScannedBarcode(
+                value: 'J001', timestamp: DateTime(2026, 1, 1), isManual: true)
+            .toJson(),
+        ScannedBarcode(value: '0000022222', timestamp: DateTime(2026, 1, 2))
+            .toJson(),
+        ScannedBarcode(value: 'J002', timestamp: DateTime(2026, 1, 2)).toJson(),
+      ]),
+    });
+    await pumpScanner(tester);
+
+    // Newest pair (0000022222 / J002) renders first, numbered 2; the manual
+    // pair (0000011111 / J001) renders second, numbered 1.
+    expect(find.text('2'), findsOneWidget);
+    expect(find.text('1'), findsOneWidget);
+
+    await tester.drag(find.byType(ListTile).last, const Offset(-500, 0));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+    await tester.tap(find.text('Delete'));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 300));
+
+    final saved = await savedValues();
+    expect(saved, hasLength(2));
+    expect(saved[0]['value'], '0000022222');
+    // Only one pair left, renumbered to 1.
+    expect(find.text('1'), findsOneWidget);
+    expect(find.text('2'), findsNothing);
+  });
+}

--- a/fivekmrun_app_flutter/test/timekeeping/manual_entry_dialog_test.dart
+++ b/fivekmrun_app_flutter/test/timekeeping/manual_entry_dialog_test.dart
@@ -1,0 +1,62 @@
+import 'package:fivekmrun_flutter/timekeeping/manual_entry_dialog.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('formatRunnerId', () {
+    test('pads digits to the 10-digit barcode format', () {
+      expect(formatRunnerId('12345'), '0000012345');
+    });
+
+    test('tolerates an already-padded 10-digit code', () {
+      expect(formatRunnerId('0000012345'), '0000012345');
+    });
+
+    test('rejects empty input', () {
+      expect(formatRunnerId(''), isNull);
+      expect(formatRunnerId('   '), isNull);
+    });
+
+    test('rejects non-numeric input', () {
+      expect(formatRunnerId('12a45'), isNull);
+    });
+
+    test('rejects more than 10 digits', () {
+      expect(formatRunnerId('123456789012'), isNull);
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(formatRunnerId('  123  '), '0000000123');
+    });
+  });
+
+  group('formatPlace', () {
+    test('prefixes with J', () {
+      expect(formatPlace('001'), 'J001');
+      expect(formatPlace('17'), 'J17');
+    });
+
+    test('rejects empty input', () {
+      expect(formatPlace(''), isNull);
+    });
+
+    test('rejects non-numeric input', () {
+      expect(formatPlace('J17'), isNull);
+    });
+  });
+
+  group('stripRunnerId', () {
+    test('removes the zero padding, keeping the meaningful digits', () {
+      expect(stripRunnerId('0000012345'), '12345');
+    });
+
+    test('keeps at least one digit for an all-zero id', () {
+      expect(stripRunnerId('0000000000'), '0');
+    });
+  });
+
+  group('stripPlace', () {
+    test('removes the J prefix', () {
+      expect(stripPlace('J001'), '001');
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/timekeeping/manual_entry_dialog_widget_test.dart
+++ b/fivekmrun_app_flutter/test/timekeeping/manual_entry_dialog_widget_test.dart
@@ -1,0 +1,174 @@
+import 'dart:async';
+
+import 'package:fivekmrun_flutter/timekeeping/manual_entry_dialog.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../localized_app.dart';
+
+void main() {
+  Future<BuildContext> pumpContext(WidgetTester tester) async {
+    late BuildContext captured;
+    await tester.pumpWidget(localizedApp(
+      Builder(builder: (context) {
+        captured = context;
+        return const SizedBox();
+      }),
+      locale: const Locale('en'),
+    ));
+    return captured;
+  }
+
+  Future<ManualEntryResult?> openDialog(
+    WidgetTester tester,
+    BuildContext context, {
+    String? initialRunnerIdDigits,
+    String? initialPlaceDigits,
+    bool lockRunnerId = false,
+    bool Function(String)? isDuplicateRunner,
+  }) {
+    final future = showDialog<ManualEntryResult>(
+      context: context,
+      builder: (context) => ManualEntryDialog(
+        initialRunnerIdDigits: initialRunnerIdDigits,
+        initialPlaceDigits: initialPlaceDigits,
+        lockRunnerId: lockRunnerId,
+        isDuplicateRunner: isDuplicateRunner ?? (_) => false,
+      ),
+    );
+    return future;
+  }
+
+  testWidgets('submitting valid input returns the formatted pair',
+      (tester) async {
+    final context = await pumpContext(tester);
+    final resultFuture = openDialog(tester, context);
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), '12345');
+    await tester.enterText(find.byType(TextField).at(1), '017');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final result = await resultFuture;
+    expect(result, isNotNull);
+    expect(result!.runnerId, '0000012345');
+    expect(result.place, 'J017');
+  });
+
+  testWidgets('invalid input shows an inline error and keeps the dialog open',
+      (tester) async {
+    final context = await pumpContext(tester);
+    final resultFuture = openDialog(tester, context);
+    await tester.pumpAndSettle();
+
+    // Leave both fields empty and try to submit.
+    await tester.tap(find.text('Save'));
+    await tester.pump();
+
+    expect(
+        find.text('Enter a valid runner ID (up to 10 digits)'), findsOneWidget);
+    expect(find.text('Enter a valid place'), findsOneWidget);
+    // The dialog is still open — Save is still there to tap.
+    expect(find.text('Save'), findsOneWidget);
+
+    // Now fill in valid values and confirm it closes.
+    await tester.enterText(find.byType(TextField).at(0), '5');
+    await tester.enterText(find.byType(TextField).at(1), '1');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(await resultFuture, isNotNull);
+  });
+
+  testWidgets('cancel returns null without validating', (tester) async {
+    final context = await pumpContext(tester);
+    final resultFuture = openDialog(tester, context);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(await resultFuture, isNull);
+  });
+
+  testWidgets(
+      'runner ID field is locked and pre-filled when completing a '
+      'dangling pair', (tester) async {
+    final context = await pumpContext(tester);
+    final resultFuture = openDialog(
+      tester,
+      context,
+      initialRunnerIdDigits: '12345',
+      lockRunnerId: true,
+    );
+    await tester.pumpAndSettle();
+
+    final runnerIdField =
+        tester.widget<TextField>(find.byType(TextField).at(0));
+    expect(runnerIdField.enabled, isFalse);
+    expect(runnerIdField.controller!.text, '12345');
+
+    await tester.enterText(find.byType(TextField).at(1), '017');
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    final result = await resultFuture;
+    expect(result!.runnerId, isNull);
+    expect(result.place, 'J017');
+  });
+
+  testWidgets('editing pre-fills both fields', (tester) async {
+    final context = await pumpContext(tester);
+    unawaited(openDialog(
+      tester,
+      context,
+      initialRunnerIdDigits: '12345',
+      initialPlaceDigits: '017',
+    ));
+    await tester.pumpAndSettle();
+
+    final runnerIdField =
+        tester.widget<TextField>(find.byType(TextField).at(0));
+    final placeField = tester.widget<TextField>(find.byType(TextField).at(1));
+    expect(runnerIdField.enabled, isTrue);
+    expect(runnerIdField.controller!.text, '12345');
+    expect(placeField.controller!.text, '017');
+  });
+
+  testWidgets('shows a non-blocking duplicate warning but still allows submit',
+      (tester) async {
+    final context = await pumpContext(tester);
+    final resultFuture = openDialog(
+      tester,
+      context,
+      isDuplicateRunner: (id) => id == '0000012345',
+    );
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), '12345');
+    await tester.enterText(find.byType(TextField).at(1), '017');
+    await tester.pump();
+
+    expect(find.text('This runner ID is already recorded'), findsOneWidget);
+
+    await tester.tap(find.text('Save'));
+    await tester.pumpAndSettle();
+
+    expect(await resultFuture, isNotNull);
+  });
+
+  testWidgets('shows a live preview of the formatted values as they type',
+      (tester) async {
+    final context = await pumpContext(tester);
+    unawaited(openDialog(tester, context));
+    await tester.pumpAndSettle();
+
+    await tester.enterText(find.byType(TextField).at(0), '5');
+    await tester.enterText(find.byType(TextField).at(1), '1');
+    await tester.pump();
+
+    expect(find.text('0000000005'), findsOneWidget);
+    expect(find.text('J1'), findsOneWidget);
+  });
+}

--- a/fivekmrun_app_flutter/test/timekeeping/scanned_barcode_test.dart
+++ b/fivekmrun_app_flutter/test/timekeeping/scanned_barcode_test.dart
@@ -1,0 +1,33 @@
+import 'package:fivekmrun_flutter/timekeeping/barcode_scanner.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('ScannedBarcode JSON', () {
+    test('round-trips isManual', () {
+      final entry = ScannedBarcode(
+        value: '0000012345',
+        timestamp: DateTime(2026, 1, 1, 10, 30),
+        isManual: true,
+      );
+
+      final decoded = ScannedBarcode.fromJson(entry.toJson());
+
+      expect(decoded.value, '0000012345');
+      expect(decoded.timestamp, DateTime(2026, 1, 1, 10, 30));
+      expect(decoded.isManual, isTrue);
+    });
+
+    test(
+        'defaults isManual to false when the key is missing — a session '
+        'saved by a previous app version must load without error', () {
+      final json = {
+        'value': '0000012345',
+        'timestamp': '2026-01-01T10:30:00.000',
+      };
+
+      final decoded = ScannedBarcode.fromJson(json);
+
+      expect(decoded.isManual, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements #200: at timekeeping, the scanner screen was the only way to record a finisher, so a damaged/unreadable barcode meant that runner couldn't be recorded at all, and a misread value couldn't be corrected. This adds a manual entry path per the issue's agreed design:

- An **"add manually"** action in the app bar (`Icons.edit_note`, alongside save/clear) opens a dialog collecting a **runner ID + place pair together** — a completed pair is always appended as two entries, so the even/odd alternation `_isExpectedCode` enforces holds by construction (no swapped-field edge case to guard against).
- **Tapping an existing pair's row** opens the same dialog pre-filled, to correct a misread value in place. Edits keep the pair's **original timestamps** and position — only the values change, preserving chronology and export line order.
- **Auto-prefix + validate, with a live preview**: the marshal types only the meaningful digits — a runner ID gets padded to the 10-digit barcode format (same convention as `formatBarcode` in `barcode_page.dart`), a place gets the `J` prefix. The resulting full code shows live in the dialog as they type. Empty/non-numeric/>10-digit runner ID input shows an inline error and keeps the dialog open — nothing is added on invalid input.
- A **non-blocking duplicate-runner-ID warning** (shown live, doesn't block submit).
- **Dangling pair handling**: if the scanned list ends on an odd count (a runner ID scanned but no place yet), "add manually" — or tapping that trailing row — completes that pair instead of starting a new one: the runner ID field is pre-filled and locked, only the place is collected.
- **Manual rows are marked** with a small edit-icon badge in the list. The exported `.txt` stays byte-identical in format (same `yy/mm/dd,HH:MM:SS,01,<value>` lines, same order) — export only ever reads `value`/`timestamp`, neither of which changed.
- `ScannedBarcode` gains an `isManual` flag that **defaults to `false` when absent** from saved JSON, so a session saved by the previous app version loads without error.
- `lastScannedValue` is updated after a manual add, so a stray camera re-detection right after doesn't duplicate it.

## Changes
- `lib/timekeeping/manual_entry_dialog.dart` (new) — `ManualEntryDialog` + the runner-ID/place format & strip helpers (`formatRunnerId`, `formatPlace`, `stripRunnerId`, `stripPlace`), each independently unit-tested.
- `lib/timekeeping/barcode_scanner.dart` — `ScannedBarcode.isManual` (+ back-compat JSON default), `_addManually`/`_editPair`/`_isDuplicateRunnerId`, the app-bar action, `ListTile.onTap` + manual badge.
- `lib/l10n/app_bg.arb` / `app_en.arb` — new strings for the dialog and the app-bar action, kept in sync (bg is primary, per the issue).

## Test plan
- New tests: `test/timekeeping/manual_entry_dialog_test.dart` (12 unit tests: padding/prefix format & strip helpers, edge cases like all-zero IDs and non-numeric/oversized input), `test/timekeeping/manual_entry_dialog_widget_test.dart` (7 widget tests: valid submit, inline validation errors keep the dialog open, cancel, locked/pre-filled runner ID for a dangling pair, pre-filled edit, non-blocking duplicate warning, live preview), `test/timekeeping/scanned_barcode_test.dart` (2 tests: `isManu...
- `flutter analyze` (full project): 0 errors, 0 new warnings — the 6 pre-existing warnings are all in unrelated files.
- `flutter test` (full suite): all 249 tests pass, no regressions.
- Manually verified on a booted Android emulator (Pixel 7 API 36): opened Timekeeping → Scanning, tapped the new "add manually" icon, watched the live preview update as digits were typed (`12345` → `0000012345`, `017` → `J017`), saved, confirmed the pair appeared in the list with the manual edit-icon badge, then tapped the row and confirmed the edit dialog opened pre-filled with both fields editable.

## Manual testing instructions
1. Timekeeping → Scanning → tap the new "add manually" icon in the app bar.
2. Enter a runner ID (e.g. `12345`) and a place (e.g. `001`); confirm the preview line under each field shows the padded/prefixed form before saving.
3. Save — the pair appears in the list with an edit-icon badge.
4. Tap that row — the dialog reopens pre-filled with both fields editable; change a value and save to confirm it updates in place.
5. Scan (or manually add) just a runner ID with no place yet, then tap "add manually" again — the runner ID field should be locked/pre-filled and only the place collected.
6. Swipe a manual pair to delete it — confirms and removes it, pair numbering stays correct.

Closes #200