### PR TITLE
feat: multi-profile support with quick switching

### DIFF
--- a/fivekmrun_app_flutter/lib/common/profile_switcher.dart
+++ b/fivekmrun_app_flutter/lib/common/profile_switcher.dart
@@ -1,0 +1,225 @@
+import 'package:collection/collection.dart';
+import 'package:fivekmrun_flutter/common/refresh_helper.dart';
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:fivekmrun_flutter/login/helpers.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/state/profile_model.dart';
+import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:fivekmrun_flutter/state/strava_resource.dart';
+import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+/// Clears and reloads every *per-user* resource for whichever profile is now
+/// active — [UserResource], [RunsResource] and the Strava connection. Device
+/// settings (push notifications, locale, theme — `LocalStorageResource`,
+/// `LocaleProvider`) are untouched, by design: switching profiles must never
+/// reset those.
+///
+/// The Strava connection is disconnected rather than swapped: `strava_client`
+/// keeps its own OAuth session in its own storage, keyed by nothing of ours,
+/// so there is no way to hold two profiles' Strava connections at once
+/// without reaching into that package's internals. Disconnecting avoids
+/// silently attributing one profile's Strava activities to another.
+void resetAndReloadForActiveProfile(BuildContext context) {
+  final authRes = Provider.of<AuthenticationResource>(context, listen: false);
+  final userRes = Provider.of<UserResource>(context, listen: false);
+  final runsRes = Provider.of<RunsResource>(context, listen: false);
+  final stravaRes = Provider.of<StravaResource>(context, listen: false);
+
+  userRes.clear();
+  runsRes.clear();
+  reportOnFailure(
+      stravaRes.deAuthenticate(), "strava deauth on profile switch");
+
+  final newUserId = authRes.getUserId();
+  userRes.currentUserId = newUserId;
+  if (newUserId != null) {
+    reportOnFailure(runsRes.getByUserId(newUserId), "runs");
+    // Piggybacks a second fetch of the same endpoint rather than trying to
+    // observe the one `currentUserId`'s setter already kicked off: that
+    // setter notifies listeners twice (once for its own barcode-only
+    // placeholder, again once the real data lands), and the two are
+    // indistinguishable from here without deeper changes to UserResource.
+    reportOnFailure(
+      userRes.getById(newUserId, true).then((user) {
+        if (user != null) {
+          authRes.updateProfileDisplay(newUserId,
+              name: user.name, avatarUrl: user.avatarUrl);
+        }
+      }),
+      "user profile cache for switcher",
+    );
+  }
+}
+
+/// Switches to [userId], prompting for that profile's password first if its
+/// token has expired — returns whether the switch completed (false if the
+/// profile doesn't exist, or the user cancelled/failed the password prompt).
+Future<bool> switchToProfile(BuildContext context, int userId) async {
+  final authRes = Provider.of<AuthenticationResource>(context, listen: false);
+  final profile = authRes.profiles.firstWhereOrNull((p) => p.userId == userId);
+  if (profile == null) return false;
+
+  if (profile.type == ProfileType.password && profile.isTokenExpired) {
+    final reauthed = await showDialog<bool>(
+      context: context,
+      builder: (context) => _ReauthDialog(profile: profile),
+    );
+    if (reauthed != true) return false;
+  } else {
+    final switched = await authRes.switchProfile(userId);
+    if (!switched) return false;
+  }
+
+  if (!context.mounted) return true;
+  resetAndReloadForActiveProfile(context);
+  // Best-effort: a telemetry failure must not surface as if the switch
+  // itself failed — the switch and resource reset above already succeeded.
+  try {
+    FirebaseAnalytics.instance.logEvent(
+        name: "profile_switch", parameters: {"type": profile.type.name});
+  } catch (_) {}
+  return true;
+}
+
+/// Removes [userId] from the switcher. If it was the active profile, falls
+/// back to another saved profile (reloading per-user data for it), or — if
+/// none remain — pops back to the login screen entirely.
+Future<void> removeProfileFromSwitcher(BuildContext context, int userId) async {
+  final authRes = Provider.of<AuthenticationResource>(context, listen: false);
+  final removedType =
+      authRes.profiles.firstWhereOrNull((p) => p.userId == userId)?.type;
+  final wasActive = authRes.activeProfileId == userId;
+
+  final newActiveId = await authRes.removeProfile(userId);
+
+  // Best-effort — see switchToProfile's identical guard.
+  try {
+    FirebaseAnalytics.instance.logEvent(
+      name: "profile_remove",
+      parameters: {"type": removedType?.name ?? "unknown"},
+    );
+  } catch (_) {}
+
+  if (!wasActive) return;
+  if (!context.mounted) return;
+
+  if (newActiveId == null) {
+    Navigator.of(context, rootNavigator: true)
+        .pushNamedAndRemoveUntil("/", (_) => false);
+  } else {
+    resetAndReloadForActiveProfile(context);
+  }
+}
+
+/// Prompts for a password (and, for a profile with no stored email — a
+/// pre-multi-profile migrated profile — the email too) to refresh an expired
+/// password profile's token, then performs the switch itself. Pops `true` on
+/// success, `null`/`false` on cancel or a failed attempt (the dialog stays
+/// open on failure so it can be retried).
+class _ReauthDialog extends StatefulWidget {
+  final Profile profile;
+
+  const _ReauthDialog({Key? key, required this.profile}) : super(key: key);
+
+  @override
+  State<_ReauthDialog> createState() => _ReauthDialogState();
+}
+
+class _ReauthDialogState extends State<_ReauthDialog> {
+  final _usernameController = TextEditingController();
+  final _passwordController = TextEditingController();
+  bool _submitting = false;
+  bool _error = false;
+
+  bool get _needsUsername => widget.profile.username == null;
+
+  @override
+  void dispose() {
+    _usernameController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _submit() async {
+    setState(() {
+      _submitting = true;
+      _error = false;
+    });
+
+    final authRes = Provider.of<AuthenticationResource>(context, listen: false);
+    final success = await authRes.reauthenticateAndSwitch(
+      widget.profile.userId,
+      _passwordController.text,
+      username: _needsUsername ? _usernameController.text.trim() : null,
+    );
+
+    if (!mounted) return;
+
+    if (success) {
+      Navigator.of(context).pop(true);
+    } else {
+      setState(() {
+        _submitting = false;
+        _error = true;
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final label = widget.profile.name.isNotEmpty
+        ? widget.profile.name
+        : widget.profile.userId.toString();
+
+    return AlertDialog(
+      title: Text(l10n.profile_switcher_reauth_title(label)),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: <Widget>[
+          if (_error)
+            Padding(
+              padding: const EdgeInsets.only(bottom: 8.0),
+              child: Text(
+                l10n.profile_switcher_reauth_error,
+                style: TextStyle(color: Theme.of(context).colorScheme.error),
+              ),
+            ),
+          if (_needsUsername)
+            TextField(
+              controller: _usernameController,
+              keyboardType: TextInputType.emailAddress,
+              decoration: InputHelpers.decoration("email"),
+            ),
+          if (_needsUsername) const SizedBox(height: 10),
+          TextField(
+            controller: _passwordController,
+            obscureText: true,
+            decoration: InputHelpers.decoration(
+                l10n.login_with_username_widget_password),
+            onSubmitted: (_) => _submitting ? null : _submit(),
+          ),
+        ],
+      ),
+      actions: <Widget>[
+        TextButton(
+          onPressed: _submitting ? null : () => Navigator.of(context).pop(),
+          child: Text(l10n.cancel),
+        ),
+        TextButton(
+          onPressed: _submitting ? null : _submit,
+          child: _submitting
+              ? const SizedBox(
+                  width: 16,
+                  height: 16,
+                  child: CircularProgressIndicator(strokeWidth: 2))
+              : Text(l10n.next),
+        ),
+      ],
+    );
+  }
+}

--- a/fivekmrun_app_flutter/lib/common/profile_switcher.dart
+++ b/fivekmrun_app_flutter/lib/common/profile_switcher.dart
@@ -114,6 +114,25 @@ Future<void> removeProfileFromSwitcher(BuildContext context, int userId) async {
   }
 }
 
+/// Prompts for a password to authenticate [profile] — upgrading it from
+/// ID-only to a password profile if needed — reloading per-user resources on
+/// success. Every other saved profile is untouched. Used where a token-gated
+/// action (e.g. Selfie submission) needs the *active* profile specifically
+/// authenticated, as distinct from [switchToProfile]'s expired-token reauth
+/// on a *different* profile. Returns whether authentication succeeded.
+Future<bool> authenticateProfileWithPassword(
+    BuildContext context, Profile profile) async {
+  final reauthed = await showDialog<bool>(
+    context: context,
+    builder: (context) => _ReauthDialog(profile: profile),
+  );
+  if (reauthed != true) return false;
+
+  if (!context.mounted) return true;
+  resetAndReloadForActiveProfile(context);
+  return true;
+}
+
 /// Prompts for a password (and, for a profile with no stored email — a
 /// pre-multi-profile migrated profile — the email too) to refresh an expired
 /// password profile's token, then performs the switch itself. Pops `true` on

--- a/fivekmrun_app_flutter/lib/common/profile_switcher_sheet.dart
+++ b/fivekmrun_app_flutter/lib/common/profile_switcher_sheet.dart
@@ -1,0 +1,118 @@
+import 'package:fivekmrun_flutter/common/profile_switcher.dart';
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/constants.dart' as constants;
+import 'package:fivekmrun_flutter/state/profile_model.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+/// Quick switcher: lists every saved profile, plus "Add profile" and "Manage
+/// profiles" — the entry point is the active profile's avatar/name (see
+/// `profile.dart`).
+///
+/// [callerContext] is the screen that opened the sheet (e.g. `profile.dart`)
+/// — every action below dismisses the sheet first and then acts using
+/// *that* context, never the sheet's own builder context, which becomes
+/// invalid the moment the sheet starts closing.
+Future<void> showProfileSwitcherSheet(BuildContext callerContext) {
+  return showModalBottomSheet<void>(
+    context: callerContext,
+    isScrollControlled: true,
+    builder: (sheetContext) =>
+        _ProfileSwitcherSheet(callerContext: callerContext),
+  );
+}
+
+class _ProfileSwitcherSheet extends StatelessWidget {
+  final BuildContext callerContext;
+
+  const _ProfileSwitcherSheet({Key? key, required this.callerContext})
+      : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final authRes = Provider.of<AuthenticationResource>(context);
+    final profiles = authRes.profiles;
+    final activeId = authRes.activeProfileId;
+
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Text(
+              l10n.profile_switcher_title,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+          ),
+          for (final profile in profiles)
+            _ProfileRow(
+              profile: profile,
+              isActive: profile.userId == activeId,
+              onSelect: () {
+                Navigator.of(context).pop();
+                switchToProfile(callerContext, profile.userId);
+              },
+            ),
+          const Divider(height: 1),
+          ListTile(
+            leading: const Icon(Icons.add),
+            title: Text(l10n.profile_switcher_add_profile),
+            enabled: profiles.length < constants.maxProfiles,
+            onTap: () {
+              Navigator.of(context).pop();
+              Navigator.of(callerContext, rootNavigator: true)
+                  .pushNamed('add-profile');
+            },
+          ),
+          ListTile(
+            leading: const Icon(Icons.manage_accounts),
+            title: Text(l10n.profile_switcher_manage_profiles),
+            onTap: () {
+              Navigator.of(context).pop();
+              Navigator.of(callerContext, rootNavigator: true)
+                  .pushNamed('manage-profiles');
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ProfileRow extends StatelessWidget {
+  final Profile profile;
+  final bool isActive;
+  final VoidCallback onSelect;
+
+  const _ProfileRow({
+    Key? key,
+    required this.profile,
+    required this.isActive,
+    required this.onSelect,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final displayName =
+        profile.name.isNotEmpty ? profile.name : profile.userId.toString();
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundImage: profile.avatarUrl.isNotEmpty
+            ? NetworkImage(profile.avatarUrl)
+            : null,
+        child: profile.avatarUrl.isEmpty ? const Icon(Icons.person) : null,
+      ),
+      title: Text(displayName),
+      subtitle: Text(profile.type == ProfileType.password
+          ? l10n.profile_switcher_type_password
+          : l10n.profile_switcher_type_id_only),
+      trailing: isActive ? const Icon(Icons.check) : null,
+      onTap: isActive ? null : onSelect,
+    );
+  }
+}

--- a/fivekmrun_app_flutter/lib/common/refresh_helper.dart
+++ b/fivekmrun_app_flutter/lib/common/refresh_helper.dart
@@ -48,12 +48,16 @@ Future<void> reportOnFailure(Future<dynamic> future, String label) async {
   try {
     await future;
   } catch (error, stackTrace) {
-    await FirebaseCrashlytics.instance.recordError(
-      error,
-      stackTrace,
-      reason: "refresh failed: $label",
-      fatal: false,
-    );
+    // Best-effort: reporting must not become a second failure on top of the
+    // one being reported — Crashlytics throws if Firebase never initialised.
+    try {
+      await FirebaseCrashlytics.instance.recordError(
+        error,
+        stackTrace,
+        reason: "refresh failed: $label",
+        fatal: false,
+      );
+    } catch (_) {}
   }
 }
 

--- a/fivekmrun_app_flutter/lib/constants.dart
+++ b/fivekmrun_app_flutter/lib/constants.dart
@@ -21,5 +21,13 @@ const String key_tokenTimestamp = "5kmrun_Token_Created";
 const int tokenExpiryDays = 30;
 const String key_lastSeenWhatsNewVersion = "5kmrun_LastSeenWhatsNewVersion";
 
+// Multi-profile storage (#184). key_userId/key_token/key_tokenTimestamp above
+// are the pre-multi-profile single-account keys — loadFromLocalStore()
+// migrates them into a one-profile list under key_profiles the first time it
+// finds no profiles list yet, then leaves them alone (harmless dead keys).
+const String key_profiles = "5kmrun_Profiles";
+const String key_activeProfileId = "5kmrun_ActiveProfileId";
+const int maxProfiles = 5;
+
 const int stravaFilterMinDistance = 4900;
 const int stravaFilterMaxDistance = 5300;

--- a/fivekmrun_app_flutter/lib/l10n/app_bg.arb
+++ b/fivekmrun_app_flutter/lib/l10n/app_bg.arb
@@ -112,6 +112,7 @@
   "login_with_id_widget_personal_id": "личен номер",
   "login_with_id_widget_participation": "Участието в ",
   "login_with_id_widget_authentication": " класацията е достъпно само с парола!",
+  "login_with_id_widget_invalid_id": "Моля въведете валиден личен номер",
 
   "login_with_username_widget_wrong_auth": "Грешно потребителско име или парола",
   "login_with_username_widget_password": "парола",
@@ -234,5 +235,24 @@
   "@whats_new_sheet_title": {
     "placeholders": { "version": { "type": "String" } }
   },
-  "whats_new_sheet_dismiss": "Разбрах"
+  "whats_new_sheet_dismiss": "Разбрах",
+
+  "profile_switcher_title": "Профили",
+  "profile_switcher_add_profile": "Добави профил",
+  "profile_switcher_manage_profiles": "Управление на профили",
+  "profile_switcher_type_password": "Парола",
+  "profile_switcher_type_id_only": "Само номер",
+  "profile_switcher_max_profiles_reached": "Достигнат е максималният брой профили (5)",
+  "profile_switcher_reauth_title": "Въведете парола за {name}",
+  "@profile_switcher_reauth_title": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "profile_switcher_reauth_error": "Грешна парола",
+
+  "manage_profiles_page_remove_title": "Премахни профила?",
+  "manage_profiles_page_remove_content": "Сигурни ли сте, че искате да премахнете профила на {name}?",
+  "@manage_profiles_page_remove_content": {
+    "placeholders": { "name": { "type": "String" } }
+  },
+  "manage_profiles_page_remove": "Премахни"
 }

--- a/fivekmrun_app_flutter/lib/l10n/app_en.arb
+++ b/fivekmrun_app_flutter/lib/l10n/app_en.arb
@@ -112,6 +112,7 @@
     "login_with_id_widget_personal_id": "personal id",
     "login_with_id_widget_participation": "Access to the ",
     "login_with_id_widget_authentication": " leaderboard requires a password!",
+    "login_with_id_widget_invalid_id": "Please enter a valid personal id",
 
     "login_with_username_widget_wrong_auth": "Wrong username or password",
     "login_with_username_widget_password": "password",
@@ -201,5 +202,18 @@
   "whats_new_page_title": "What's new",
   "whats_new_page_current_version": "Current version: {version}",
   "whats_new_sheet_title": "New in version {version}",
-  "whats_new_sheet_dismiss": "Got it"
+  "whats_new_sheet_dismiss": "Got it",
+
+  "profile_switcher_title": "Profiles",
+  "profile_switcher_add_profile": "Add profile",
+  "profile_switcher_manage_profiles": "Manage profiles",
+  "profile_switcher_type_password": "Password",
+  "profile_switcher_type_id_only": "ID only",
+  "profile_switcher_max_profiles_reached": "Maximum number of profiles reached (5)",
+  "profile_switcher_reauth_title": "Enter the password for {name}",
+  "profile_switcher_reauth_error": "Wrong password",
+
+  "manage_profiles_page_remove_title": "Remove this profile?",
+  "manage_profiles_page_remove_content": "Are you sure you want to remove {name}'s profile?",
+  "manage_profiles_page_remove": "Remove"
 }

--- a/fivekmrun_app_flutter/lib/login/login.dart
+++ b/fivekmrun_app_flutter/lib/login/login.dart
@@ -7,6 +7,14 @@ import 'package:url_launcher/url_launcher.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 
 class Login extends StatefulWidget {
+  /// True when reached via "Add profile" (#184) rather than the app's
+  /// initial sign-in — swaps in an app bar (with a back button, since this
+  /// is now a screen pushed on top of the switcher) and has the two login
+  /// widgets add a profile instead of starting the one and only session.
+  final bool addingProfile;
+
+  const Login({Key? key, this.addingProfile = false}) : super(key: key);
+
   @override
   _LoginState createState() => _LoginState();
 }
@@ -24,6 +32,13 @@ class _LoginState extends State<Login> {
     final l10n = AppLocalizations.of(context)!;
 
     return Scaffold(
+      appBar: widget.addingProfile
+          ? AppBar(
+              leading: BackButton(color: Colors.white),
+              title: Text(l10n.profile_switcher_add_profile),
+              centerTitle: true,
+            )
+          : null,
       body: SafeArea(
         child: Stack(
           children: <Widget>[
@@ -34,10 +49,15 @@ class _LoginState extends State<Login> {
                 child: Column(
                   mainAxisAlignment: MainAxisAlignment.end,
                   children: <Widget>[
-                    this._buildLogo(),
-                    SizedBox(height: 10),
+                    if (!widget.addingProfile) ...[
+                      this._buildLogo(),
+                      SizedBox(height: 10),
+                    ],
                     Spacer(),
-                    this.loginWithId ? LoginWithId() : LoginWithUsername(),
+                    this.loginWithId
+                        ? LoginWithId(addingProfile: widget.addingProfile)
+                        : LoginWithUsername(
+                            addingProfile: widget.addingProfile),
                     SizedBox(height: 4),
                     SizedBox(
                       width: double.infinity,
@@ -49,24 +69,27 @@ class _LoginState extends State<Login> {
                       ),
                     ),
                     Spacer(),
-                    Text(l10n.login_widget_no_registration),
-                    GestureDetector(
-                      onTap: () => _loadRegistrationScreen(),
-                      child: Text(l10n.login_widget_register,
-                          style: TextStyle(
-                              color: accentColor,
-                              fontSize: 14,
-                              fontWeight: FontWeight.bold)),
-                    )
+                    if (!widget.addingProfile) ...[
+                      Text(l10n.login_widget_no_registration),
+                      GestureDetector(
+                        onTap: () => _loadRegistrationScreen(),
+                        child: Text(l10n.login_widget_register,
+                            style: TextStyle(
+                                color: accentColor,
+                                fontSize: 14,
+                                fontWeight: FontWeight.bold)),
+                      )
+                    ],
                   ],
                 ),
               ),
             ),
-            Positioned(
-              top: 8,
-              right: 8,
-              child: LocaleSwitcherWidget(),
-            ),
+            if (!widget.addingProfile)
+              Positioned(
+                top: 8,
+                right: 8,
+                child: LocaleSwitcherWidget(),
+              ),
           ],
         ),
       ),

--- a/fivekmrun_app_flutter/lib/login/login_with_id.dart
+++ b/fivekmrun_app_flutter/lib/login/login_with_id.dart
@@ -1,3 +1,4 @@
+import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:fivekmrun_flutter/login/helpers.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
@@ -6,7 +7,13 @@ import 'package:provider/provider.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 
 class LoginWithId extends StatefulWidget {
-  LoginWithId({Key? key}) : super(key: key);
+  /// See [LoginWithUsername.addingProfile] — same meaning here. An ID-only
+  /// profile has no confirm-and-switch step of its own (unlike the initial
+  /// login's "loginPreview"), so adding one just pops back to the caller on
+  /// success without touching the currently active profile's data.
+  final bool addingProfile;
+
+  LoginWithId({Key? key, this.addingProfile = false}) : super(key: key);
 
   @override
   _LoginWithIdState createState() => _LoginWithIdState();
@@ -23,13 +30,35 @@ class _LoginWithIdState extends State<LoginWithId> {
   }
 
   void onPressed() async {
+    final l10n = AppLocalizations.of(context)!;
     final userId = parseUserId(numberInputController.text);
     if (userId == null) {
       ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Моля въведете валиден личен номер')),
+        SnackBar(content: Text(l10n.login_with_id_widget_invalid_id)),
       );
       return;
     }
+
+    if (widget.addingProfile) {
+      try {
+        await Provider.of<AuthenticationResource>(context, listen: false)
+            .authenticateWithUserId(userId, makeActive: false);
+      } on MaxProfilesReachedException {
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(l10n.profile_switcher_max_profiles_reached)),
+        );
+        return;
+      }
+      // Best-effort: a telemetry failure must not block completing the add.
+      try {
+        FirebaseAnalytics.instance
+            .logEvent(name: "profile_add", parameters: {"type": "idOnly"});
+      } catch (_) {}
+      if (mounted) Navigator.of(context).pop(true);
+      return;
+    }
+
     await Provider.of<AuthenticationResource>(context, listen: false)
         .authenticateWithUserId(userId);
     Provider.of<UserResource>(context, listen: false).currentUserId = userId;

--- a/fivekmrun_app_flutter/lib/login/login_with_username.dart
+++ b/fivekmrun_app_flutter/lib/login/login_with_username.dart
@@ -8,6 +8,16 @@ import 'package:provider/provider.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 
 class LoginWithUsername extends StatefulWidget {
+  /// True when this screen is adding an additional profile (#184) rather
+  /// than starting the app's one and only session — the new profile is
+  /// added without disturbing whichever profile is currently active, and
+  /// success pops back to the caller instead of replacing the whole
+  /// navigation stack with "home".
+  final bool addingProfile;
+
+  const LoginWithUsername({Key? key, this.addingProfile = false})
+      : super(key: key);
+
   @override
   _LoginWithUsernameState createState() => _LoginWithUsernameState();
 }
@@ -16,6 +26,7 @@ class _LoginWithUsernameState extends State<LoginWithUsername> {
   final usernameInputController = TextEditingController();
   final passwordInputController = TextEditingController();
   bool loginError = false;
+  bool maxProfilesError = false;
 
   @override
   void dispose() {
@@ -29,19 +40,45 @@ class _LoginWithUsernameState extends State<LoginWithUsername> {
     String password = this.passwordInputController.text;
 
     Provider.of<AuthenticationResource>(context, listen: false)
-        .authenticate(username, password)
+        .authenticate(username, password, makeActive: !widget.addingProfile)
         .then((isAuthenticated) {
-      FirebaseCrashlytics.instance
-          .log("authenticate with username result: $isAuthenticated");
+      // Best-effort, like the error-path reporting below: a telemetry
+      // failure here must not be mistaken for an authentication failure by
+      // the catchError below, which would otherwise show the wrong error
+      // message despite a successful login.
+      try {
+        FirebaseCrashlytics.instance
+            .log("authenticate with username result: $isAuthenticated");
+      } catch (_) {}
 
       if (isAuthenticated) {
-        FirebaseAnalytics.instance.logEvent(name: "login");
-        if (mounted) setState(() => this.loginError = false);
-        Navigator.pushNamedAndRemoveUntil(context, "home", (_) => false);
+        if (mounted) {
+          setState(() {
+            this.loginError = false;
+            this.maxProfilesError = false;
+          });
+        }
+        if (widget.addingProfile) {
+          try {
+            FirebaseAnalytics.instance.logEvent(
+                name: "profile_add", parameters: {"type": "password"});
+          } catch (_) {}
+          Navigator.of(context).pop(true);
+        } else {
+          try {
+            FirebaseAnalytics.instance.logEvent(name: "login");
+          } catch (_) {}
+          Navigator.pushNamedAndRemoveUntil(context, "home", (_) => false);
+        }
       } else {
         if (mounted) setState(() => this.loginError = true);
       }
     }).catchError((error, stackTrace) {
+      if (error is MaxProfilesReachedException) {
+        if (mounted) setState(() => this.maxProfilesError = true);
+        return;
+      }
+
       // Show the error before reporting it. Reporting alone left the tap with
       // no visible effect at all, indistinguishable from a request that is
       // merely slow. Every failure mode of authenticate() lands here — a
@@ -72,6 +109,18 @@ class _LoginWithUsernameState extends State<LoginWithUsername> {
               child: Text(
                 AppLocalizations.of(context)!
                     .login_with_username_widget_wrong_auth,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Theme.of(context).colorScheme.error,
+                ),
+              ),
+            ),
+          if (this.maxProfilesError)
+            Padding(
+              padding: const EdgeInsets.fromLTRB(8, 0, 8, 10),
+              child: Text(
+                AppLocalizations.of(context)!
+                    .profile_switcher_max_profiles_reached,
                 textAlign: TextAlign.center,
                 style: TextStyle(
                   color: Theme.of(context).colorScheme.error,

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:fivekmrun_flutter/home.dart';
 import 'package:fivekmrun_flutter/login/helpers.dart';
 import 'package:fivekmrun_flutter/login/login.dart';
 import 'package:fivekmrun_flutter/login/loginPreview.dart';
+import 'package:fivekmrun_flutter/manage_profiles_page.dart';
 import 'package:fivekmrun_flutter/push_notifications_manager.dart';
 import 'package:fivekmrun_flutter/settings_page.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
@@ -133,6 +134,8 @@ class MyApp extends StatelessWidget {
             initialRoute: _initialRoute,
             routes: {
               '/': (_) => Login(),
+              'add-profile': (_) => Login(addingProfile: true),
+              'manage-profiles': (_) => ManageProfilesPage(),
               'loginPreview': (_) => LoginPreview(),
               'home': (_) => Home(),
               'barcode': (_) => BarcodePage(),

--- a/fivekmrun_app_flutter/lib/manage_profiles_page.dart
+++ b/fivekmrun_app_flutter/lib/manage_profiles_page.dart
@@ -1,0 +1,81 @@
+import 'package:fivekmrun_flutter/common/profile_switcher.dart';
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/state/profile_model.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+/// Lists every saved profile with a remove action. Reordering is out of
+/// scope for #184 — the acceptance criteria only call for add/switch/remove.
+class ManageProfilesPage extends StatelessWidget {
+  const ManageProfilesPage({Key? key}) : super(key: key);
+
+  Future<void> _confirmAndRemove(
+      BuildContext context, Profile profile, AppLocalizations l10n) async {
+    final displayName =
+        profile.name.isNotEmpty ? profile.name : profile.userId.toString();
+
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: Text(l10n.manage_profiles_page_remove_title),
+        content: Text(l10n.manage_profiles_page_remove_content(displayName)),
+        actions: <Widget>[
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(l10n.cancel),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            style: TextButton.styleFrom(foregroundColor: Colors.red),
+            child: Text(l10n.manage_profiles_page_remove),
+          ),
+        ],
+      ),
+    );
+
+    if (confirmed == true) {
+      await removeProfileFromSwitcher(context, profile.userId);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AppLocalizations.of(context)!;
+    final authRes = Provider.of<AuthenticationResource>(context);
+    final activeId = authRes.activeProfileId;
+
+    return Scaffold(
+      appBar: AppBar(
+        leading: BackButton(color: Colors.white),
+        title: Text(l10n.profile_switcher_manage_profiles),
+        centerTitle: true,
+      ),
+      body: ListView(
+        children: <Widget>[
+          for (final profile in authRes.profiles)
+            ListTile(
+              leading: CircleAvatar(
+                backgroundImage: profile.avatarUrl.isNotEmpty
+                    ? NetworkImage(profile.avatarUrl)
+                    : null,
+                child:
+                    profile.avatarUrl.isEmpty ? const Icon(Icons.person) : null,
+              ),
+              title: Text(profile.name.isNotEmpty
+                  ? profile.name
+                  : profile.userId.toString()),
+              subtitle: Text(profile.type == ProfileType.password
+                  ? l10n.profile_switcher_type_password
+                  : l10n.profile_switcher_type_id_only),
+              trailing: IconButton(
+                icon: const Icon(Icons.delete_outline),
+                onPressed: () => _confirmAndRemove(context, profile, l10n),
+              ),
+              selected: profile.userId == activeId,
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/fivekmrun_app_flutter/lib/offline_chart/offline_chart_page.dart
+++ b/fivekmrun_app_flutter/lib/offline_chart/offline_chart_page.dart
@@ -1,11 +1,10 @@
+import 'package:fivekmrun_flutter/common/profile_switcher.dart';
 import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/results_list.dart';
 import 'package:fivekmrun_flutter/common/select_button.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
 import 'package:fivekmrun_flutter/state/offline_results_resource.dart';
 import 'package:fivekmrun_flutter/state/result_model.dart';
-import 'package:fivekmrun_flutter/state/runs_resource.dart';
-import 'package:fivekmrun_flutter/state/user_resource.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -103,12 +102,10 @@ class _OfflineChartPageState extends State<OfflineChartPage> {
               child: new Text(
                   AppLocalizations.of(context)!.offline_chart_page_login),
               onPressed: () async {
-                await authResource.logout();
-                Provider.of<UserResource>(context, listen: false).clear();
-                Provider.of<RunsResource>(context, listen: false).clear();
-
-                Navigator.of(context, rootNavigator: true)
-                    .pushNamedAndRemoveUntil("/", (_) => false);
+                Navigator.of(context).pop();
+                final profile = authResource.activeProfile;
+                if (profile == null) return;
+                await authenticateProfileWithPassword(this.context, profile);
               },
             ),
             TextButton(

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -6,6 +6,7 @@ import 'package:fivekmrun_flutter/charts/runs_by_route_chart.dart';
 import 'package:fivekmrun_flutter/common/avatar.dart';
 import 'package:fivekmrun_flutter/common/badges.dart';
 import 'package:fivekmrun_flutter/common/legioner_status_helper.dart';
+import 'package:fivekmrun_flutter/common/profile_switcher_sheet.dart';
 import 'package:fivekmrun_flutter/common/refresh_helper.dart';
 import 'package:fivekmrun_flutter/common/run_card.dart';
 import 'package:fivekmrun_flutter/constants.dart';
@@ -125,25 +126,31 @@ class ProfileDashboard extends StatelessWidget {
                     ),
                     Expanded(
                       flex: 5,
-                      child: Column(
-                        children: <Widget>[
-                          Stack(
-                            children: <Widget>[
-                              Avatar(url: user?.avatarUrl ?? ""),
-                              Positioned(
-                                bottom: 0,
-                                right: 0,
-                                child: profileBadge(),
-                              )
-                            ],
-                          ),
-                          Text(
-                            user?.name ?? "",
-                            style: textTheme.titleMedium,
-                            textAlign: TextAlign.center,
-                          ),
-                          Text(""),
-                        ],
+                      child: GestureDetector(
+                        // The quick profile switcher (#184) — this avatar/name
+                        // is the app's stand-in for an app-bar identity menu,
+                        // since the Profile tab has no literal app bar.
+                        onTap: () => showProfileSwitcherSheet(context),
+                        child: Column(
+                          children: <Widget>[
+                            Stack(
+                              children: <Widget>[
+                                Avatar(url: user?.avatarUrl ?? ""),
+                                Positioned(
+                                  bottom: 0,
+                                  right: 0,
+                                  child: profileBadge(),
+                                )
+                              ],
+                            ),
+                            Text(
+                              user?.name ?? "",
+                              style: textTheme.titleMedium,
+                              textAlign: TextAlign.center,
+                            ),
+                            Text(""),
+                          ],
+                        ),
                       ),
                     ),
                     Expanded(

--- a/fivekmrun_app_flutter/lib/profile.dart
+++ b/fivekmrun_app_flutter/lib/profile.dart
@@ -143,10 +143,18 @@ class ProfileDashboard extends StatelessWidget {
                                 )
                               ],
                             ),
-                            Text(
-                              user?.name ?? "",
-                              style: textTheme.titleMedium,
-                              textAlign: TextAlign.center,
+                            Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: <Widget>[
+                                Flexible(
+                                  child: Text(
+                                    user?.name ?? "",
+                                    style: textTheme.titleMedium,
+                                    textAlign: TextAlign.center,
+                                  ),
+                                ),
+                                const Icon(Icons.expand_more, size: 18),
+                              ],
                             ),
                             Text(""),
                           ],

--- a/fivekmrun_app_flutter/lib/settings_page.dart
+++ b/fivekmrun_app_flutter/lib/settings_page.dart
@@ -1,15 +1,14 @@
 import 'package:fivekmrun_flutter/push_notifications_manager.dart';
 import 'package:fivekmrun_flutter/state/authentication_resource.dart';
 import 'package:fivekmrun_flutter/state/local_storage_resource.dart';
-import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:fivekmrun_flutter/whats_new/whats_new_page.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 import 'package:flutter/material.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
 import 'common/locale_switch.dart';
+import 'common/profile_switcher.dart';
 import 'common/strava_connect.dart';
-import 'state/user_resource.dart';
 
 class SettingsPage extends StatefulWidget {
   SettingsPage({Key? key}) : super(key: key);
@@ -29,13 +28,27 @@ class _SettingsPageState extends State<SettingsPage> {
     localStorage.isSubscribedForGeneral.then(
         (value) => setState(() => this._pushNotificationsSubscribed = value));
 
+    // Removes only the current profile — falls back to another saved
+    // profile if one remains, or to the login screen if this was the last
+    // one. Either way Settings itself is no longer the right screen to be
+    // on: closing it back to Profile is what lets the user actually see
+    // which profile (if any) they landed on, rather than silently staying
+    // on a Settings screen that gives no indication anything changed.
+    //
+    // Only pop when a profile is left to fall back to: when none remain,
+    // removeProfileFromSwitcher already replaces the *entire* navigation
+    // stack with the login screen — popping again on top of that would
+    // empty the Navigator's history outright (`context.mounted` isn't a
+    // reliable guard here, since disposal of the old route isn't
+    // necessarily flushed to the element tree the instant that call
+    // returns).
     final logout = () async {
-      await authResource.logout();
-      Provider.of<UserResource>(context, listen: false).clear();
-      Provider.of<RunsResource>(context, listen: false).clear();
-
-      Navigator.of(context, rootNavigator: true)
-          .pushNamedAndRemoveUntil("/", (_) => false);
+      final userId = authResource.getUserId();
+      if (userId == null) return;
+      await removeProfileFromSwitcher(context, userId);
+      if (authResource.activeProfileId != null && context.mounted) {
+        Navigator.of(context, rootNavigator: true).pop();
+      }
     };
 
     final dividerColor = Theme.of(context).colorScheme.secondary;

--- a/fivekmrun_app_flutter/lib/state/authentication_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/authentication_resource.dart
@@ -98,23 +98,25 @@ class AuthenticationResource extends ChangeNotifier {
     return true;
   }
 
-  /// Re-authenticates an already-saved password profile whose token has
-  /// expired (or was rejected), refreshing its token and making it active.
-  /// Returns false on a wrong password / failed request — the profile is
-  /// left untouched so the prompt can be retried.
+  /// Re-authenticates an already-saved profile with a password, refreshing
+  /// its token and making it active. Works for a password profile whose
+  /// token has expired (or was rejected) as much as for an ID-only profile
+  /// that needs upgrading to a password one (e.g. to unlock a token-gated
+  /// action like Selfie submission) — either way the profile is updated in
+  /// place by user id, so every other saved profile is untouched. Returns
+  /// false on a wrong password / failed request — the profile is left
+  /// untouched so the prompt can be retried.
   ///
   /// The server authenticates by email, not by user id, so this needs the
   /// profile's email — normally its stored [Profile.username], but that's
   /// null for a profile migrated from the pre-multi-profile single-account
-  /// keys (which never recorded it). [username] lets the caller supply it in
-  /// that case; once supplied it's saved on the profile so this only needs
-  /// asking for it once.
+  /// keys (which never recorded it), or one that started ID-only. [username]
+  /// lets the caller supply it in that case; once supplied it's saved on the
+  /// profile so this only needs asking for it once.
   Future<bool> reauthenticateAndSwitch(int userId, String password,
       {String? username}) async {
     final existing = _profiles.firstWhereOrNull((p) => p.userId == userId);
-    if (existing == null || existing.type != ProfileType.password) {
-      return false;
-    }
+    if (existing == null) return false;
 
     final email = username ?? existing.username;
     if (email == null) return false;
@@ -141,6 +143,7 @@ class AuthenticationResource extends ChangeNotifier {
 
     await this._upsertProfile(
       existing.copyWith(
+        type: ProfileType.password,
         token: token,
         tokenTimestamp: DateTime.now().millisecondsSinceEpoch,
         username: email,

--- a/fivekmrun_app_flutter/lib/state/authentication_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/authentication_resource.dart
@@ -1,17 +1,54 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:fivekmrun_flutter/state/profile_model.dart';
 import 'package:flutter/widgets.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:fivekmrun_flutter/constants.dart' as constants;
 
-class AuthenticationResource extends ChangeNotifier {
-  String? _token;
-  int? _userId;
+/// Thrown by [AuthenticationResource.authenticate] /
+/// [AuthenticationResource.authenticateWithUserId] when adding a genuinely
+/// new profile would exceed [constants.maxProfiles].
+class MaxProfilesReachedException implements Exception {}
 
-  Future<bool> authenticate(String username, String password) async {
-    FirebaseCrashlytics.instance.log("authenticate username - $username");
+/// Best-effort: telemetry must never become the reason profile management
+/// fails, and must never require a real Firebase app in tests either.
+void _logCrashlytics(String message) {
+  try {
+    FirebaseCrashlytics.instance.log(message);
+  } catch (_) {}
+}
+
+void _setCrashlyticsUser(String? userId) {
+  try {
+    FirebaseCrashlytics.instance.setUserIdentifier(userId ?? "");
+  } catch (_) {}
+}
+
+/// Holds every profile saved on this device and which one is active.
+///
+/// `getToken()`/`getUserId()`/`isLoggedIn()` describe the *active* profile —
+/// every existing call site keeps working unchanged. `isLoggedIn()` in
+/// particular has always meant "has a usable password-profile token", not
+/// "has an active identity": an ID-only profile has never had a token, so
+/// `getUserId()` (used to gate navigation/data-fetching) and `isLoggedIn()`
+/// (used to gate token-only actions like Selfie submission) are deliberately
+/// different questions.
+class AuthenticationResource extends ChangeNotifier {
+  List<Profile> _profiles = <Profile>[];
+  int? _activeProfileId;
+
+  List<Profile> get profiles => List.unmodifiable(_profiles);
+  int? get activeProfileId => _activeProfileId;
+
+  Profile? get activeProfile =>
+      _profiles.firstWhereOrNull((p) => p.userId == _activeProfileId);
+
+  Future<bool> authenticate(String username, String password,
+      {bool makeActive = true}) async {
+    _logCrashlytics("authenticate username - $username");
 
     HttpClient httpClient = new HttpClient();
     HttpClientRequest request =
@@ -30,7 +67,16 @@ class AuthenticationResource extends ChangeNotifier {
       final userId = map["answer"]["id"];
 
       if (token != null && token != "" && userId != null) {
-        await this._onLoginSuccess(userId, token);
+        await this._upsertProfile(
+          Profile(
+            userId: userId,
+            type: ProfileType.password,
+            token: token,
+            tokenTimestamp: DateTime.now().millisecondsSinceEpoch,
+            username: username,
+          ),
+          makeActive: makeActive,
+        );
 
         return true;
       } else {
@@ -41,83 +87,238 @@ class AuthenticationResource extends ChangeNotifier {
     }
   }
 
-  Future<bool> authenticateWithUserId(int userId) async {
-    FirebaseCrashlytics.instance.log("authenticate userID - $userId");
+  Future<bool> authenticateWithUserId(int userId,
+      {bool makeActive = true}) async {
+    _logCrashlytics("authenticate userID - $userId");
 
-    await this._onLoginSuccess(userId, null);
+    await this._upsertProfile(
+      Profile(userId: userId, type: ProfileType.idOnly),
+      makeActive: makeActive,
+    );
     return true;
   }
 
+  /// Re-authenticates an already-saved password profile whose token has
+  /// expired (or was rejected), refreshing its token and making it active.
+  /// Returns false on a wrong password / failed request — the profile is
+  /// left untouched so the prompt can be retried.
+  ///
+  /// The server authenticates by email, not by user id, so this needs the
+  /// profile's email — normally its stored [Profile.username], but that's
+  /// null for a profile migrated from the pre-multi-profile single-account
+  /// keys (which never recorded it). [username] lets the caller supply it in
+  /// that case; once supplied it's saved on the profile so this only needs
+  /// asking for it once.
+  Future<bool> reauthenticateAndSwitch(int userId, String password,
+      {String? username}) async {
+    final existing = _profiles.firstWhereOrNull((p) => p.userId == userId);
+    if (existing == null || existing.type != ProfileType.password) {
+      return false;
+    }
+
+    final email = username ?? existing.username;
+    if (email == null) return false;
+
+    HttpClient httpClient = new HttpClient();
+    HttpClientRequest request =
+        await httpClient.postUrl(Uri.parse("https://5kmrun.bg/api/auth"));
+    request.headers.set('content-type', 'application/x-www-form-urlencoded');
+    request.write("userEmail=$email&userPassword=$password");
+
+    HttpClientResponse response = await request.close();
+    String reply = await response.transform(utf8.decoder).join();
+    httpClient.close();
+    Map<String, dynamic> map = json.decode(reply);
+    List<String> errors = List.from(map["errors"]);
+
+    if (errors.isNotEmpty) return false;
+
+    final token = map["answer"]["tkn"];
+    final returnedUserId = map["answer"]["id"];
+    if (token == null || token == "" || returnedUserId != userId) {
+      return false;
+    }
+
+    await this._upsertProfile(
+      existing.copyWith(
+        token: token,
+        tokenTimestamp: DateTime.now().millisecondsSinceEpoch,
+        username: email,
+      ),
+      makeActive: true,
+    );
+    return true;
+  }
+
+  /// Switches the active profile without touching its token. Returns false
+  /// if [userId] has no saved profile.
+  Future<bool> switchProfile(int userId) async {
+    if (!_profiles.any((p) => p.userId == userId)) return false;
+
+    this._activeProfileId = userId;
+    _setCrashlyticsUser(userId.toString());
+    await this._persistActiveProfileId();
+    notifyListeners();
+    return true;
+  }
+
+  /// Removes a saved profile (clearing its token locally — no server-side
+  /// invalidation call, per #184's grooming). If it was the active profile,
+  /// falls back to another saved profile, or to no active profile (login
+  /// screen) if none remain. Returns the new active profile id, or null.
+  Future<int?> removeProfile(int userId) async {
+    final wasActive = this._activeProfileId == userId;
+    this._profiles.removeWhere((p) => p.userId == userId);
+    await this._persistProfiles();
+
+    if (wasActive) {
+      this._activeProfileId =
+          this._profiles.isNotEmpty ? this._profiles.first.userId : null;
+      _setCrashlyticsUser(this._activeProfileId?.toString());
+      await this._persistActiveProfileId();
+    }
+
+    notifyListeners();
+    return this._activeProfileId;
+  }
+
   String? getToken() {
-    return this._token;
+    final profile = activeProfile;
+    if (profile == null || profile.isTokenExpired) return null;
+    return profile.token;
   }
 
   int? getUserId() {
-    return this._userId;
+    return activeProfile?.userId;
   }
 
   bool isLoggedIn() {
-    return this._token != null && this._userId != null;
+    return getToken() != null;
   }
 
-  void _setUserId(int? userId) {
-    this._userId = userId;
-    FirebaseCrashlytics.instance.setUserIdentifier(userId?.toString() ?? "");
-  }
-
-  void _setToken(String? token) {
-    this._token = token;
-    FirebaseCrashlytics.instance
-        .setCustomKey("hasToken", token != null && token != "");
-  }
-
+  /// Clears every saved profile — used by the "sign out of this device"
+  /// action (Settings), as distinct from [removeProfile] which removes a
+  /// single profile from the switcher.
   Future<void> logout() async {
-    FirebaseCrashlytics.instance.log("logout() started");
-    this._setUserId(null);
-    this._setToken(null);
+    _logCrashlytics("logout() started");
+    this._profiles = <Profile>[];
+    this._activeProfileId = null;
+    _setCrashlyticsUser(null);
 
     SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.remove(constants.key_profiles);
+    await prefs.remove(constants.key_activeProfileId);
+    // Pre-multi-profile keys — removed too so a stale copy can't resurrect
+    // itself on the next migration check.
     await prefs.remove(constants.key_userId);
     await prefs.remove(constants.key_token);
     await prefs.remove(constants.key_tokenTimestamp);
-    FirebaseCrashlytics.instance.log("logout() completed");
+
+    notifyListeners();
+    _logCrashlytics("logout() completed");
   }
 
-  Future<void> _onLoginSuccess(int userId, String? token) async {
-    this._setUserId(userId);
-    this._setToken(token);
+  /// Updates the profile's cached display fields (name/avatar), used once
+  /// [UserResource] resolves the full profile for a profile that was added
+  /// or migrated with only an id.
+  Future<void> updateProfileDisplay(int userId,
+      {required String name, required String avatarUrl}) async {
+    final index = this._profiles.indexWhere((p) => p.userId == userId);
+    if (index == -1) return;
+    if (this._profiles[index].name == name &&
+        this._profiles[index].avatarUrl == avatarUrl) {
+      return;
+    }
 
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    await prefs.setInt(constants.key_userId, userId);
+    this._profiles[index] =
+        this._profiles[index].copyWith(name: name, avatarUrl: avatarUrl);
+    await this._persistProfiles();
+    notifyListeners();
+  }
 
-    if (token != null) {
-      final timestamp = DateTime.now().millisecondsSinceEpoch;
-      await prefs.setString(constants.key_token, token);
-      await prefs.setInt(constants.key_tokenTimestamp, timestamp);
+  Future<void> _upsertProfile(Profile profile,
+      {required bool makeActive}) async {
+    final index = this._profiles.indexWhere((p) => p.userId == profile.userId);
+    if (index != -1) {
+      // Re-adding an existing profile refreshes it (e.g. an ID-only profile
+      // upgraded to a password one, or a token refresh) instead of
+      // duplicating it — the cap below only applies to genuinely new ids.
+      this._profiles[index] = profile.copyWith(
+        username: profile.username ?? this._profiles[index].username,
+        name: this._profiles[index].name,
+        avatarUrl: this._profiles[index].avatarUrl,
+      );
     } else {
-      await prefs.remove(constants.key_token);
-      await prefs.remove(constants.key_tokenTimestamp);
+      if (this._profiles.length >= constants.maxProfiles) {
+        throw MaxProfilesReachedException();
+      }
+      this._profiles.add(profile);
+    }
+
+    await this._persistProfiles();
+
+    if (makeActive) {
+      this._activeProfileId = profile.userId;
+      _setCrashlyticsUser(profile.userId.toString());
+      await this._persistActiveProfileId();
+    }
+
+    notifyListeners();
+  }
+
+  Future<void> _persistProfiles() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    await prefs.setString(constants.key_profiles,
+        jsonEncode(this._profiles.map((p) => p.toJson()).toList()));
+  }
+
+  Future<void> _persistActiveProfileId() async {
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    if (this._activeProfileId != null) {
+      await prefs.setInt(constants.key_activeProfileId, this._activeProfileId!);
+    } else {
+      await prefs.remove(constants.key_activeProfileId);
     }
   }
 
   Future<void> loadFromLocalStore() async {
     SharedPreferences prefs = await SharedPreferences.getInstance();
 
-    // load user ID
+    final profilesJson = prefs.getString(constants.key_profiles);
+    if (profilesJson != null) {
+      final List<dynamic> decoded = jsonDecode(profilesJson);
+      this._profiles = decoded
+          .map((e) => Profile.fromJson(e as Map<String, dynamic>))
+          .toList();
+      this._activeProfileId = prefs.getInt(constants.key_activeProfileId);
+    } else {
+      await this._migrateSingleAccount(prefs);
+    }
+
+    _setCrashlyticsUser(this._activeProfileId?.toString());
+  }
+
+  /// One-time migration for a device that predates multi-profile support:
+  /// wraps the old single `{userId, token, timestamp}` keys into a one-item
+  /// profile list, so an existing user is never signed out by the upgrade.
+  Future<void> _migrateSingleAccount(SharedPreferences prefs) async {
     final userId = prefs.getInt(constants.key_userId);
-    this._setUserId(userId);
+    if (userId == null) return;
 
     final token = prefs.getString(constants.key_token);
-    if (token != null) {
-      final timestamp = prefs.getInt(constants.key_tokenTimestamp);
-      if (timestamp != null) {
-        final created = DateTime.fromMillisecondsSinceEpoch(timestamp);
-        final expiresAt =
-            created.add(new Duration(days: constants.tokenExpiryDays));
-        if (expiresAt.isAfter(DateTime.now())) {
-          this._setToken(token);
-        }
-      }
-    }
+    final tokenTimestamp = prefs.getInt(constants.key_tokenTimestamp);
+
+    this._profiles = <Profile>[
+      Profile(
+        userId: userId,
+        type: token != null ? ProfileType.password : ProfileType.idOnly,
+        token: token,
+        tokenTimestamp: tokenTimestamp,
+      ),
+    ];
+    this._activeProfileId = userId;
+
+    await this._persistProfiles();
+    await this._persistActiveProfileId();
   }
 }

--- a/fivekmrun_app_flutter/lib/state/profile_model.dart
+++ b/fivekmrun_app_flutter/lib/state/profile_model.dart
@@ -1,0 +1,99 @@
+import 'package:fivekmrun_flutter/constants.dart' as constants;
+
+/// Mirrors the two existing login paths in [AuthenticationResource].
+enum ProfileType { password, idOnly }
+
+/// A single saved account on this device. Multiple profiles let a user (most
+/// commonly a parent managing their kid's account too) switch between
+/// accounts without signing out.
+class Profile {
+  final int userId;
+  final ProfileType type;
+
+  /// Null for an [ProfileType.idOnly] profile — no password was ever
+  /// provided, so there is nothing to authenticate token-gated actions with.
+  final String? token;
+
+  /// Epoch milliseconds; null for an [ProfileType.idOnly] profile.
+  final int? tokenTimestamp;
+
+  /// The email a password profile logs in with. Never a secret by itself,
+  /// but stored so an expired-token re-auth only needs to prompt for the
+  /// password — the server authenticates by email, not by user id, so
+  /// without this there would be nothing to re-authenticate with. Null for
+  /// an [ProfileType.idOnly] profile, and for a profile migrated from the
+  /// pre-multi-profile single-account keys (which never recorded it either).
+  final String? username;
+
+  /// Cached for the switcher UI so it doesn't need a network round trip to
+  /// list saved profiles. Refreshed opportunistically once [UserResource]
+  /// loads the full profile.
+  final String name;
+  final String avatarUrl;
+
+  const Profile({
+    required this.userId,
+    required this.type,
+    this.token,
+    this.tokenTimestamp,
+    this.username,
+    this.name = "",
+    this.avatarUrl = "",
+  });
+
+  /// An ID-only profile has nothing to expire. A password profile with no
+  /// stored token/timestamp counts as expired — there is nothing valid to
+  /// use.
+  bool get isTokenExpired {
+    if (type == ProfileType.idOnly) return false;
+    if (token == null || token!.isEmpty || tokenTimestamp == null) {
+      return true;
+    }
+
+    final created = DateTime.fromMillisecondsSinceEpoch(tokenTimestamp!);
+    final expiresAt = created.add(Duration(days: constants.tokenExpiryDays));
+    return !expiresAt.isAfter(DateTime.now());
+  }
+
+  Profile copyWith({
+    ProfileType? type,
+    String? token,
+    int? tokenTimestamp,
+    String? username,
+    String? name,
+    String? avatarUrl,
+  }) {
+    return Profile(
+      userId: userId,
+      type: type ?? this.type,
+      token: token ?? this.token,
+      tokenTimestamp: tokenTimestamp ?? this.tokenTimestamp,
+      username: username ?? this.username,
+      name: name ?? this.name,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'userId': userId,
+        'type': type.name,
+        'token': token,
+        'tokenTimestamp': tokenTimestamp,
+        'username': username,
+        'name': name,
+        'avatarUrl': avatarUrl,
+      };
+
+  factory Profile.fromJson(Map<String, dynamic> json) => Profile(
+        userId: json['userId'] as int,
+        type: ProfileType.values.firstWhere(
+          (t) => t.name == json['type'],
+          orElse: () => ProfileType.idOnly,
+        ),
+        token: json['token'] as String?,
+        tokenTimestamp: json['tokenTimestamp'] as int?,
+        username: json['username'] as String?,
+        name: json['name'] as String? ?? "",
+        avatarUrl: json['avatarUrl'] as String? ?? "",
+      );
+}

--- a/fivekmrun_app_flutter/test/common/login_with_id_add_profile_test.dart
+++ b/fivekmrun_app_flutter/test/common/login_with_id_add_profile_test.dart
@@ -1,0 +1,116 @@
+import 'package:fivekmrun_flutter/login/login_with_id.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+import '../localized_app.dart';
+
+class _FakeAuthResource extends AuthenticationResource {
+  bool addProfileCalled = false;
+  bool? lastMakeActive;
+
+  @override
+  Future<bool> authenticateWithUserId(int userId,
+      {bool makeActive = true}) async {
+    addProfileCalled = true;
+    lastMakeActive = makeActive;
+    return true;
+  }
+}
+
+class _MaxProfilesAuthResource extends AuthenticationResource {
+  @override
+  Future<bool> authenticateWithUserId(int userId,
+      {bool makeActive = true}) async {
+    throw MaxProfilesReachedException();
+  }
+}
+
+// Pushes LoginWithId(addingProfile: true) on a button tap and renders
+// whatever it pops with — mirrors login_with_username_test.dart's harness.
+class _AddProfileHarness extends StatefulWidget {
+  @override
+  State<_AddProfileHarness> createState() => _AddProfileHarnessState();
+}
+
+class _AddProfileHarnessState extends State<_AddProfileHarness> {
+  Object? _poppedValue;
+  bool _hasPopped = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (_hasPopped) Text('popped:$_poppedValue'),
+          ElevatedButton(
+            onPressed: () async {
+              final result = await Navigator.of(context).push<Object?>(
+                MaterialPageRoute(
+                  builder: (_) =>
+                      Scaffold(body: LoginWithId(addingProfile: true)),
+                ),
+              );
+              setState(() {
+                _hasPopped = true;
+                _poppedValue = result;
+              });
+            },
+            child: const Text('open'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// The provider must wrap the whole app, not just `home` — see the identical
+// note in login_with_username_test.dart.
+Widget _buildAddProfileWidget(AuthenticationResource auth) {
+  return ChangeNotifierProvider<AuthenticationResource>.value(
+    value: auth,
+    child: localizedApp(_AddProfileHarness()),
+  );
+}
+
+const _maxProfilesText = 'Достигнат е максималният брой профили (5)';
+
+void main() {
+  group('LoginWithId addingProfile', () {
+    testWidgets('adds an ID-only profile without switching, pops true',
+        (tester) async {
+      final auth = _FakeAuthResource();
+      await tester.pumpWidget(_buildAddProfileWidget(auth));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '13731');
+      await tester.tap(find.byType(ElevatedButton).last);
+      await tester.pumpAndSettle();
+
+      expect(auth.addProfileCalled, isTrue);
+      expect(auth.lastMakeActive, isFalse);
+      expect(find.byType(LoginWithId), findsNothing);
+      expect(find.text('popped:true'), findsOneWidget);
+    });
+
+    testWidgets('shows a distinct message once the profile cap is reached',
+        (tester) async {
+      await tester
+          .pumpWidget(_buildAddProfileWidget(_MaxProfilesAuthResource()));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField), '13731');
+      await tester.tap(find.byType(ElevatedButton).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text(_maxProfilesText), findsOneWidget);
+      expect(find.byType(LoginWithId), findsOneWidget);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/common/login_with_username_test.dart
+++ b/fivekmrun_app_flutter/test/common/login_with_username_test.dart
@@ -19,7 +19,8 @@ class _ThrowingAuthResource extends AuthenticationResource {
   _ThrowingAuthResource({this.error = 'network error'});
 
   @override
-  Future<bool> authenticate(String username, String password) async {
+  Future<bool> authenticate(String username, String password,
+      {bool makeActive = true}) async {
     throw error;
   }
 }
@@ -35,8 +36,81 @@ Widget _buildWidget(AuthenticationResource auth) {
   );
 }
 
+class _FakeAuthResource extends AuthenticationResource {
+  bool addProfileCalled = false;
+  bool? lastMakeActive;
+
+  @override
+  Future<bool> authenticate(String username, String password,
+      {bool makeActive = true}) async {
+    addProfileCalled = true;
+    lastMakeActive = makeActive;
+    return true;
+  }
+}
+
+class _MaxProfilesAuthResource extends AuthenticationResource {
+  @override
+  Future<bool> authenticate(String username, String password,
+      {bool makeActive = true}) async {
+    throw MaxProfilesReachedException();
+  }
+}
+
+// Pushes LoginWithUsername(addingProfile: true) on a button tap and renders
+// whatever it pops with, so the addingProfile success path — pop(true)
+// instead of pushNamedAndRemoveUntil("home") — is directly observable.
+class _AddProfileHarness extends StatefulWidget {
+  @override
+  State<_AddProfileHarness> createState() => _AddProfileHarnessState();
+}
+
+class _AddProfileHarnessState extends State<_AddProfileHarness> {
+  Object? _poppedValue;
+  bool _hasPopped = false;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          if (_hasPopped) Text('popped:$_poppedValue'),
+          ElevatedButton(
+            onPressed: () async {
+              final result = await Navigator.of(context).push<Object?>(
+                MaterialPageRoute(
+                  builder: (_) =>
+                      Scaffold(body: LoginWithUsername(addingProfile: true)),
+                ),
+              );
+              setState(() {
+                _hasPopped = true;
+                _poppedValue = result;
+              });
+            },
+            child: const Text('open'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+// The provider must wrap the whole `localizedApp` (MaterialApp), not just
+// its `home` route's content — a route pushed via Navigator.push lives in
+// the Overlay as a sibling of `home`, not a descendant of it, so a provider
+// scoped inside `home` would be invisible to LoginWithUsername once pushed.
+Widget _buildAddProfileWidget(AuthenticationResource auth) {
+  return ChangeNotifierProvider<AuthenticationResource>.value(
+    value: auth,
+    child: localizedApp(_AddProfileHarness()),
+  );
+}
+
 // The Bulgarian text, since localizedApp defaults to bg.
 const _errorText = 'Грешно потребителско име или парола';
+const _maxProfilesText = 'Достигнат е максималният брой профили (5)';
 
 void main() {
   group('LoginWithUsername', () {
@@ -92,6 +166,45 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text(_errorText), findsOneWidget);
+    });
+  });
+
+  group('LoginWithUsername addingProfile', () {
+    testWidgets('adds without disturbing the active profile, pops true',
+        (tester) async {
+      final auth = _FakeAuthResource();
+      await tester.pumpWidget(_buildAddProfileWidget(auth));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first, 'kid@example.com');
+      await tester.enterText(find.byType(TextField).last, 'password123');
+      await tester.tap(find.byType(ElevatedButton).last);
+      await tester.pumpAndSettle();
+
+      expect(auth.addProfileCalled, isTrue);
+      expect(auth.lastMakeActive, isFalse);
+      expect(find.byType(LoginWithUsername), findsNothing);
+      expect(find.text('popped:true'), findsOneWidget);
+    });
+
+    testWidgets('shows a distinct message once the profile cap is reached',
+        (tester) async {
+      await tester
+          .pumpWidget(_buildAddProfileWidget(_MaxProfilesAuthResource()));
+
+      await tester.tap(find.text('open'));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first, 'kid@example.com');
+      await tester.enterText(find.byType(TextField).last, 'password123');
+      await tester.tap(find.byType(ElevatedButton).last);
+      await tester.pumpAndSettle();
+
+      expect(find.text(_maxProfilesText), findsOneWidget);
+      // Still on the add-profile screen — nothing was popped.
+      expect(find.byType(LoginWithUsername), findsOneWidget);
     });
   });
 }

--- a/fivekmrun_app_flutter/test/common/profile_switcher_test.dart
+++ b/fivekmrun_app_flutter/test/common/profile_switcher_test.dart
@@ -1,0 +1,255 @@
+import 'package:fivekmrun_flutter/common/profile_switcher.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/state/local_storage_resource.dart';
+import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:fivekmrun_flutter/state/strava_resource.dart';
+import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../localized_app.dart';
+
+/// Avoids exercising StravaResource.deAuthenticate's real strava_client call
+/// (which needs a fully configured OAuth client) — same pattern as
+/// UserResource's success path being untestable without a real Firebase app
+/// (see test/state/user_resource_test.dart's note); only observing that it
+/// was *called* matters for the "no bleed" acceptance criterion.
+class _NoOpStravaResource extends StravaResource {
+  bool deauthCalled = false;
+
+  @override
+  Future<void> deAuthenticate() async {
+    deauthCalled = true;
+  }
+}
+
+// UserResource.getById's success path calls FirebaseAnalytics, which needs a
+// real Firebase app (see test/state/user_resource_test.dart) — throwing
+// (simulating "offline") keeps this on the safe fallback path that assigns
+// the *requested* user id, which is what proves the switch reloaded for the
+// new profile rather than leaving the old one's data in place. (The other
+// fallback — a non-JSON response — sets a sentinel id of -1 instead, which
+// wouldn't distinguish "reloaded for 222" from "reloaded for anything".)
+final _offlineFallbackClient =
+    MockClient((_) async => throw http.ClientException("offline"));
+
+Widget _harness({
+  required AuthenticationResource authRes,
+  required UserResource userRes,
+  required RunsResource runsRes,
+  required _NoOpStravaResource stravaRes,
+  required LocalStorageResource localStorage,
+  required void Function(BuildContext) captureContext,
+}) {
+  return MultiProvider(
+    providers: <ChangeNotifierProvider<dynamic>>[
+      ChangeNotifierProvider<AuthenticationResource>.value(value: authRes),
+      ChangeNotifierProvider<UserResource>.value(value: userRes),
+      ChangeNotifierProvider<RunsResource>.value(value: runsRes),
+      ChangeNotifierProvider<StravaResource>.value(value: stravaRes),
+      ChangeNotifierProvider<LocalStorageResource>.value(value: localStorage),
+    ],
+    child: localizedApp(Builder(builder: (context) {
+      captureContext(context);
+      return const SizedBox();
+    })),
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('switchToProfile', () {
+    testWidgets(
+        'switches, reloads per-user resources for the new profile, and '
+        'leaves device settings untouched', (tester) async {
+      SharedPreferences.setMockInitialValues(
+          {'push_notifications_subscribed_general': true});
+
+      final authRes = AuthenticationResource();
+      await authRes.authenticateWithUserId(111);
+      await authRes.authenticateWithUserId(222, makeActive: false);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+      final stravaRes = _NoOpStravaResource();
+      final localStorage = LocalStorageResource();
+
+      // Seed with profile 111's data, as if it had already been loaded —
+      // this is what must NOT bleed into profile 222 after the switch.
+      userRes.currentUserId = 111;
+      await tester.pump();
+
+      late BuildContext ctx;
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+        stravaRes: stravaRes,
+        localStorage: localStorage,
+        captureContext: (c) => ctx = c,
+      ));
+      await tester.pump();
+
+      final result = await switchToProfile(ctx, 222);
+      await tester.pump();
+
+      expect(result, isTrue);
+      expect(authRes.getUserId(), 222);
+      expect(userRes.value?.id, 222);
+      expect(stravaRes.deauthCalled, isTrue);
+
+      // Device-level settings are untouched by the switch.
+      expect(await localStorage.isSubscribedForGeneral, isTrue);
+    });
+
+    testWidgets('returns false for an unknown profile id', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final authRes = AuthenticationResource();
+      await authRes.authenticateWithUserId(111);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+      final stravaRes = _NoOpStravaResource();
+      final localStorage = LocalStorageResource();
+
+      late BuildContext ctx;
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+        stravaRes: stravaRes,
+        localStorage: localStorage,
+        captureContext: (c) => ctx = c,
+      ));
+      await tester.pump();
+
+      final result = await switchToProfile(ctx, 999);
+
+      expect(result, isFalse);
+      expect(authRes.getUserId(), 111);
+      expect(stravaRes.deauthCalled, isFalse);
+    });
+
+    testWidgets(
+        'an expired password profile prompts for its password before '
+        'completing the switch', (tester) async {
+      final expiredTimestamp = DateTime.now()
+          .subtract(const Duration(days: 31))
+          .millisecondsSinceEpoch;
+      SharedPreferences.setMockInitialValues({
+        'push_notifications_subscribed_general': true,
+        '5kmrun_Profiles': '['
+            '{"userId":111,"type":"idOnly","token":null,"tokenTimestamp":null,'
+            '"username":null,"name":"","avatarUrl":""},'
+            '{"userId":222,"type":"password","token":"stale",'
+            '"tokenTimestamp":$expiredTimestamp,'
+            '"username":"kid@example.com","name":"Kid","avatarUrl":""}'
+            ']',
+        '5kmrun_ActiveProfileId': 111,
+      });
+      final authRes = AuthenticationResource();
+      await authRes.loadFromLocalStore();
+      expect(authRes.profiles.firstWhere((p) => p.userId == 222).isTokenExpired,
+          isTrue);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+      final stravaRes = _NoOpStravaResource();
+      final localStorage = LocalStorageResource();
+
+      late BuildContext ctx;
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+        stravaRes: stravaRes,
+        localStorage: localStorage,
+        captureContext: (c) => ctx = c,
+      ));
+      await tester.pump();
+
+      // Not awaited: the dialog blocks until dismissed, and this test only
+      // needs to observe that it appeared.
+      switchToProfile(ctx, 222);
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+      // The switch has not completed yet — still on the original profile.
+      expect(authRes.getUserId(), 111);
+
+      // Dismiss it (Cancel) so the test doesn't leak a pending dialog.
+      await tester.tap(find.text('Отказ'));
+      await tester.pumpAndSettle();
+    });
+  });
+
+  group('removeProfileFromSwitcher', () {
+    testWidgets(
+        'removing the active profile falls back to another and '
+        'reloads for it', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final authRes = AuthenticationResource();
+      await authRes.authenticateWithUserId(111);
+      await authRes.authenticateWithUserId(222, makeActive: false);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+      final stravaRes = _NoOpStravaResource();
+      final localStorage = LocalStorageResource();
+
+      late BuildContext ctx;
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+        stravaRes: stravaRes,
+        localStorage: localStorage,
+        captureContext: (c) => ctx = c,
+      ));
+      await tester.pump();
+
+      await removeProfileFromSwitcher(ctx, 111);
+      await tester.pump();
+
+      expect(authRes.getUserId(), 222);
+      expect(userRes.value?.id, 222);
+      expect(authRes.profiles, hasLength(1));
+    });
+
+    testWidgets('removing a non-active profile does not reload anything',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final authRes = AuthenticationResource();
+      await authRes.authenticateWithUserId(111);
+      await authRes.authenticateWithUserId(222, makeActive: false);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+      final stravaRes = _NoOpStravaResource();
+      final localStorage = LocalStorageResource();
+
+      late BuildContext ctx;
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+        stravaRes: stravaRes,
+        localStorage: localStorage,
+        captureContext: (c) => ctx = c,
+      ));
+      await tester.pump();
+
+      await removeProfileFromSwitcher(ctx, 222);
+      await tester.pump();
+
+      expect(authRes.getUserId(), 111);
+      expect(stravaRes.deauthCalled, isFalse);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/offline_chart/offline_chart_page_test.dart
+++ b/fivekmrun_app_flutter/test/offline_chart/offline_chart_page_test.dart
@@ -1,15 +1,66 @@
 import 'dart:convert';
 
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 import 'package:fivekmrun_flutter/offline_chart/offline_chart_page.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
 import 'package:fivekmrun_flutter/state/offline_results_resource.dart';
+import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:fivekmrun_flutter/state/user_resource.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:http/http.dart' as http;
 import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
 import '../localized_app.dart';
 
 const _jsonHeaders = {"content-type": "application/json; charset=utf-8"};
+
+// UserResource's success path needs a real Firebase app — throwing
+// (simulating "offline") keeps it on the safe fallback path, same pattern as
+// test/common/profile_switcher_test.dart.
+final _offlineFallbackClient =
+    MockClient((_) async => throw http.ClientException("offline"));
+
+/// Hosts OfflineChartPage behind a named route, with the app's real
+/// localization delegates, so the "participate" flow's un-authenticated
+/// path (which navigates to the root-level "/" route) has somewhere to
+/// land — mirrors ../localized_app.dart but adds named routes, which that
+/// helper doesn't support.
+Widget _harness({
+  required AuthenticationResource authRes,
+  required UserResource userRes,
+  required RunsResource runsRes,
+  required OfflineResultsResource resource,
+}) {
+  return MultiProvider(
+    providers: <ChangeNotifierProvider<dynamic>>[
+      ChangeNotifierProvider<AuthenticationResource>.value(value: authRes),
+      ChangeNotifierProvider<UserResource>.value(value: userRes),
+      ChangeNotifierProvider<RunsResource>.value(value: runsRes),
+    ],
+    child: MaterialApp(
+      locale: const Locale('bg'),
+      localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      initialRoute: '/home',
+      routes: <String, WidgetBuilder>{
+        '/': (_) => const Scaffold(body: Text('login-screen')),
+        '/home': (_) => OfflineChartPage(
+              thisWeekResource: resource,
+              lastWeekResource: resource,
+            ),
+      },
+    ),
+  );
+}
 
 void main() {
   testWidgets(
@@ -49,5 +100,46 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(requestCount, greaterThan(requestsBeforeRefresh));
+  });
+
+  group('participating with an unauthenticated active profile', () {
+    testWidgets(
+        'prompting to authenticate leaves other saved profiles untouched',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final authRes = AuthenticationResource();
+      // Active profile has no token (ID-only) — participating requires a
+      // password, per goToAddEntry()'s isLoggedIn() gate.
+      await authRes.authenticateWithUserId(13731);
+      await authRes.authenticateWithUserId(18880, makeActive: false);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+      final resource = OfflineResultsResource(
+        client: MockClient((_) async =>
+            http.Response(jsonEncode({"runners": []}), 200,
+                headers: _jsonHeaders)),
+      );
+
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+        resource: resource,
+      ));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Участвай'));
+      await tester.pumpAndSettle();
+
+      expect(find.byType(AlertDialog), findsOneWidget);
+
+      await tester.tap(find.widgetWithText(TextButton, 'Вход с парола'));
+      await tester.pumpAndSettle();
+
+      // The other saved profile must survive — only the active profile's
+      // own authentication state should change.
+      expect(authRes.profiles.map((p) => p.userId), contains(18880));
+    });
   });
 }

--- a/fivekmrun_app_flutter/test/settings_page_test.dart
+++ b/fivekmrun_app_flutter/test/settings_page_test.dart
@@ -1,0 +1,170 @@
+import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
+import 'package:fivekmrun_flutter/settings_page.dart';
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/state/locale_provider.dart';
+import 'package:fivekmrun_flutter/state/runs_resource.dart';
+import 'package:fivekmrun_flutter/state/strava_resource.dart';
+import 'package:fivekmrun_flutter/state/user_resource.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Avoids exercising StravaResource.deAuthenticate's real strava_client call
+/// (which needs a fully configured OAuth client) — same pattern as
+/// test/common/profile_switcher_test.dart's identical helper.
+class _NoOpStravaResource extends StravaResource {
+  @override
+  Future<void> deAuthenticate() async {}
+}
+
+// UserResource/RunsResource's success paths need a real Firebase app —
+// throwing (simulating "offline") keeps them on the safe fallback path, same
+// pattern as test/common/profile_switcher_test.dart.
+final _offlineFallbackClient =
+    MockClient((_) async => throw http.ClientException("offline"));
+
+/// Stands in for profile.dart: pushes SettingsPage on the *root* navigator
+/// exactly the way `goToSettings` does there, so this test can assert on
+/// what's actually left in the stack after sign-out (a bare `home:` widget
+/// can't stand in for that — there'd be nothing for the root-navigator pop
+/// to reveal).
+class _ProfileHarness extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          const Text('profile-screen'),
+          ElevatedButton(
+            onPressed: () => Navigator.of(context, rootNavigator: true)
+                .push(MaterialPageRoute<void>(builder: (_) => SettingsPage())),
+            child: const Text('open settings'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+/// With the app's real localization delegates so `AppLocalizations.of`
+/// resolves, and a named "/" route for `removeProfileFromSwitcher`'s
+/// no-profiles-left path to land on — mirrors test/localized_app.dart but
+/// adds that, which the shared helper doesn't support.
+Widget _harness({
+  required AuthenticationResource authRes,
+  required UserResource userRes,
+  required RunsResource runsRes,
+}) {
+  return MultiProvider(
+    providers: <ChangeNotifierProvider<dynamic>>[
+      ChangeNotifierProvider<AuthenticationResource>.value(value: authRes),
+      ChangeNotifierProvider<UserResource>.value(value: userRes),
+      ChangeNotifierProvider<RunsResource>.value(value: runsRes),
+      ChangeNotifierProvider<StravaResource>.value(value: _NoOpStravaResource()),
+      ChangeNotifierProvider<LocaleProvider>.value(value: LocaleProvider()),
+    ],
+    child: MaterialApp(
+      locale: const Locale('bg'),
+      localizationsDelegates: const <LocalizationsDelegate<dynamic>>[
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      // A relative initial route (no leading "/") skips Flutter's
+      // deep-link-style initial-route generation, which would otherwise
+      // seed "/" beneath it regardless of whether anything ever navigates
+      // there — see the note this replaced for how that bit before.
+      initialRoute: 'profile',
+      routes: <String, WidgetBuilder>{
+        '/': (_) => const Scaffold(body: Text('login-screen')),
+        'profile': (_) => _ProfileHarness(),
+      },
+    ),
+  );
+}
+
+/// SettingsPage.build() creates a fresh LocalStorageResource() and calls
+/// setState from its future's `.then()` on every build, unconditionally —
+/// so it reschedules another build every single time and pumpAndSettle
+/// never quiesces. A bounded number of pumps is enough for our async chains
+/// (SharedPreferences/mocked HTTP) to resolve without hitting that loop.
+Future<void> _pumpBounded(WidgetTester tester) async {
+  for (var i = 0; i < 40; i++) {
+    await tester.pump(const Duration(milliseconds: 50));
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SettingsPage sign-out', () {
+    testWidgets(
+        'with another saved profile, signing out falls back to it and '
+        'returns to the profile screen', (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final authRes = AuthenticationResource();
+      await authRes.authenticateWithUserId(13731);
+      await authRes.authenticateWithUserId(18880, makeActive: false);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+      ));
+      await _pumpBounded(tester);
+
+      await tester.tap(find.text('open settings'));
+      await _pumpBounded(tester);
+      expect(find.byType(SettingsPage), findsOneWidget);
+
+      await tester.tap(find.byIcon(Icons.exit_to_app));
+      await _pumpBounded(tester);
+
+      // The other saved profile must survive sign-out and become active...
+      expect(authRes.profiles.map((p) => p.userId), contains(18880));
+      expect(authRes.getUserId(), 18880);
+      // ...and Settings must close back to the profile screen — staying put
+      // gives no indication the active profile actually changed.
+      expect(find.byType(SettingsPage), findsNothing);
+      expect(find.text('profile-screen'), findsOneWidget);
+    });
+
+    testWidgets('with no other saved profile, signing out goes to login',
+        (tester) async {
+      SharedPreferences.setMockInitialValues({});
+      final authRes = AuthenticationResource();
+      await authRes.authenticateWithUserId(13731);
+
+      final userRes = UserResource(client: _offlineFallbackClient);
+      final runsRes = RunsResource(client: _offlineFallbackClient);
+
+      await tester.pumpWidget(_harness(
+        authRes: authRes,
+        userRes: userRes,
+        runsRes: runsRes,
+      ));
+      await _pumpBounded(tester);
+
+      await tester.tap(find.text('open settings'));
+      await _pumpBounded(tester);
+
+      await tester.tap(find.byIcon(Icons.exit_to_app));
+      await _pumpBounded(tester);
+
+      expect(authRes.profiles, isEmpty);
+      expect(find.text('login-screen'), findsOneWidget);
+      expect(find.byType(SettingsPage), findsNothing);
+      expect(find.text('profile-screen'), findsNothing);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/authentication_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/authentication_resource_test.dart
@@ -1,0 +1,279 @@
+import 'dart:convert';
+
+import 'package:fivekmrun_flutter/constants.dart' as constants;
+import 'package:fivekmrun_flutter/state/authentication_resource.dart';
+import 'package:fivekmrun_flutter/state/profile_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+String _profilesJson(List<Profile> profiles) =>
+    jsonEncode(profiles.map((p) => p.toJson()).toList());
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('authenticateWithUserId', () {
+    test('adds an ID-only profile and makes it active by default', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+
+      final result = await auth.authenticateWithUserId(111);
+
+      expect(result, isTrue);
+      expect(auth.getUserId(), 111);
+      expect(auth.getToken(), isNull);
+      expect(auth.isLoggedIn(), isFalse);
+      expect(auth.profiles, hasLength(1));
+      expect(auth.profiles.single.type, ProfileType.idOnly);
+    });
+
+    test('adding with makeActive: false keeps the current profile active',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+
+      await auth.authenticateWithUserId(222, makeActive: false);
+
+      expect(auth.getUserId(), 111);
+      expect(auth.profiles.map((p) => p.userId), containsAll([111, 222]));
+    });
+
+    test('re-adding an existing profile refreshes it instead of duplicating',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111, makeActive: false);
+
+      await auth.authenticateWithUserId(111);
+
+      expect(auth.profiles, hasLength(1));
+      expect(auth.getUserId(), 111);
+    });
+
+    test('rejects a genuinely new profile once at the cap', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      for (var i = 0; i < constants.maxProfiles; i++) {
+        await auth.authenticateWithUserId(i, makeActive: false);
+      }
+
+      await expectLater(
+        auth.authenticateWithUserId(999, makeActive: false),
+        throwsA(isA<MaxProfilesReachedException>()),
+      );
+      expect(auth.profiles, hasLength(constants.maxProfiles));
+    });
+
+    test('persists the profile list and active id', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+
+      await auth.authenticateWithUserId(111);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(constants.key_profiles), isNotNull);
+      expect(prefs.getInt(constants.key_activeProfileId), 111);
+    });
+  });
+
+  group('switchProfile', () {
+    test('switches to a saved profile', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+      await auth.authenticateWithUserId(222, makeActive: false);
+
+      final result = await auth.switchProfile(222);
+
+      expect(result, isTrue);
+      expect(auth.getUserId(), 222);
+    });
+
+    test(
+        'returns false and leaves the active profile unchanged for an '
+        'unknown id', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+
+      final result = await auth.switchProfile(999);
+
+      expect(result, isFalse);
+      expect(auth.getUserId(), 111);
+    });
+  });
+
+  group('removeProfile', () {
+    test('removing a non-active profile leaves the active one unchanged',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+      await auth.authenticateWithUserId(222, makeActive: false);
+
+      final newActive = await auth.removeProfile(222);
+
+      expect(newActive, 111);
+      expect(auth.getUserId(), 111);
+      expect(auth.profiles, hasLength(1));
+    });
+
+    test('removing the active profile falls back to another saved profile',
+        () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+      await auth.authenticateWithUserId(222, makeActive: false);
+
+      final newActive = await auth.removeProfile(111);
+
+      expect(newActive, 222);
+      expect(auth.getUserId(), 222);
+    });
+
+    test('removing the last profile leaves no active profile', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+
+      final newActive = await auth.removeProfile(111);
+
+      expect(newActive, isNull);
+      expect(auth.getUserId(), isNull);
+      expect(auth.profiles, isEmpty);
+    });
+  });
+
+  group('logout', () {
+    test('clears every saved profile', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+      await auth.authenticateWithUserId(222, makeActive: false);
+
+      await auth.logout();
+
+      expect(auth.profiles, isEmpty);
+      expect(auth.getUserId(), isNull);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(constants.key_profiles), isNull);
+      expect(prefs.getInt(constants.key_activeProfileId), isNull);
+    });
+  });
+
+  group('updateProfileDisplay', () {
+    test('updates the cached name/avatar for a saved profile', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+
+      await auth.updateProfileDisplay(111,
+          name: 'Ivan', avatarUrl: 'https://example.com/a.png');
+
+      expect(auth.profiles.single.name, 'Ivan');
+      expect(auth.profiles.single.avatarUrl, 'https://example.com/a.png');
+    });
+
+    test('is a no-op for an unknown profile id', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+      await auth.authenticateWithUserId(111);
+
+      await auth.updateProfileDisplay(999, name: 'X', avatarUrl: 'Y');
+
+      expect(auth.profiles.single.name, '');
+    });
+  });
+
+  group('loadFromLocalStore', () {
+    test('loads an already-saved profile list', () async {
+      final profiles = [
+        Profile(userId: 111, type: ProfileType.idOnly, name: 'A'),
+        Profile(
+            userId: 222,
+            type: ProfileType.password,
+            token: 'tkn',
+            tokenTimestamp: DateTime.now().millisecondsSinceEpoch,
+            name: 'B'),
+      ];
+      SharedPreferences.setMockInitialValues({
+        constants.key_profiles: _profilesJson(profiles),
+        constants.key_activeProfileId: 222,
+      });
+      final auth = AuthenticationResource();
+
+      await auth.loadFromLocalStore();
+
+      expect(auth.profiles.map((p) => p.userId), [111, 222]);
+      expect(auth.getUserId(), 222);
+      expect(auth.isLoggedIn(), isTrue);
+    });
+
+    test('migrates the pre-multi-profile single password-account keys',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        constants.key_userId: 555,
+        constants.key_token: 'legacy-token',
+        constants.key_tokenTimestamp: DateTime.now().millisecondsSinceEpoch,
+      });
+      final auth = AuthenticationResource();
+
+      await auth.loadFromLocalStore();
+
+      expect(auth.profiles, hasLength(1));
+      expect(auth.profiles.single.userId, 555);
+      expect(auth.profiles.single.type, ProfileType.password);
+      expect(auth.getUserId(), 555);
+      expect(auth.getToken(), 'legacy-token');
+      expect(auth.isLoggedIn(), isTrue);
+
+      // The migration is persisted, so a following launch reads the new
+      // profiles list directly rather than re-migrating.
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString(constants.key_profiles), isNotNull);
+    });
+
+    test('migrates the pre-multi-profile single ID-only account', () async {
+      SharedPreferences.setMockInitialValues({
+        constants.key_userId: 555,
+      });
+      final auth = AuthenticationResource();
+
+      await auth.loadFromLocalStore();
+
+      expect(auth.profiles.single.type, ProfileType.idOnly);
+      expect(auth.getUserId(), 555);
+      expect(auth.isLoggedIn(), isFalse);
+    });
+
+    test('an expired migrated token is not usable, but the identity is kept',
+        () async {
+      SharedPreferences.setMockInitialValues({
+        constants.key_userId: 555,
+        constants.key_token: 'legacy-token',
+        constants.key_tokenTimestamp: DateTime.now()
+            .subtract(const Duration(days: 31))
+            .millisecondsSinceEpoch,
+      });
+      final auth = AuthenticationResource();
+
+      await auth.loadFromLocalStore();
+
+      expect(auth.getUserId(), 555);
+      expect(auth.getToken(), isNull);
+      expect(auth.isLoggedIn(), isFalse);
+    });
+
+    test('starts with no profiles on a fresh install', () async {
+      SharedPreferences.setMockInitialValues({});
+      final auth = AuthenticationResource();
+
+      await auth.loadFromLocalStore();
+
+      expect(auth.profiles, isEmpty);
+      expect(auth.getUserId(), isNull);
+    });
+  });
+}

--- a/fivekmrun_app_flutter/test/state/profile_model_test.dart
+++ b/fivekmrun_app_flutter/test/state/profile_model_test.dart
@@ -1,0 +1,93 @@
+import 'package:fivekmrun_flutter/state/profile_model.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Profile.isTokenExpired', () {
+    test('an ID-only profile never expires', () {
+      final profile = Profile(userId: 1, type: ProfileType.idOnly);
+      expect(profile.isTokenExpired, isFalse);
+    });
+
+    test('a password profile with a recent token is not expired', () {
+      final profile = Profile(
+        userId: 1,
+        type: ProfileType.password,
+        token: 'tkn',
+        tokenTimestamp: DateTime.now().millisecondsSinceEpoch,
+      );
+      expect(profile.isTokenExpired, isFalse);
+    });
+
+    test('a password profile past the 30-day window is expired', () {
+      final profile = Profile(
+        userId: 1,
+        type: ProfileType.password,
+        token: 'tkn',
+        tokenTimestamp: DateTime.now()
+            .subtract(const Duration(days: 31))
+            .millisecondsSinceEpoch,
+      );
+      expect(profile.isTokenExpired, isTrue);
+    });
+
+    test('a password profile with no token is expired', () {
+      final profile = Profile(userId: 1, type: ProfileType.password);
+      expect(profile.isTokenExpired, isTrue);
+    });
+  });
+
+  group('Profile JSON', () {
+    test('round-trips every field', () {
+      final profile = Profile(
+        userId: 42,
+        type: ProfileType.password,
+        token: 'tkn',
+        tokenTimestamp: 1000,
+        username: 'user@example.com',
+        name: 'Ivan',
+        avatarUrl: 'https://example.com/a.png',
+      );
+
+      final decoded = Profile.fromJson(profile.toJson());
+
+      expect(decoded.userId, 42);
+      expect(decoded.type, ProfileType.password);
+      expect(decoded.token, 'tkn');
+      expect(decoded.tokenTimestamp, 1000);
+      expect(decoded.username, 'user@example.com');
+      expect(decoded.name, 'Ivan');
+      expect(decoded.avatarUrl, 'https://example.com/a.png');
+    });
+
+    test('defaults name/avatarUrl to empty when missing', () {
+      final decoded = Profile.fromJson({'userId': 1, 'type': 'idOnly'});
+      expect(decoded.name, '');
+      expect(decoded.avatarUrl, '');
+      expect(decoded.username, isNull);
+    });
+
+    test('falls back to idOnly for an unrecognized type', () {
+      final decoded =
+          Profile.fromJson({'userId': 1, 'type': 'somethingUnknown'});
+      expect(decoded.type, ProfileType.idOnly);
+    });
+  });
+
+  group('Profile.copyWith', () {
+    test('overrides only the given fields', () {
+      final original = Profile(
+        userId: 1,
+        type: ProfileType.idOnly,
+        name: 'Ivan',
+        avatarUrl: 'url',
+      );
+
+      final updated = original.copyWith(name: 'Petar');
+
+      expect(updated.userId, 1);
+      expect(updated.type, ProfileType.idOnly);
+      expect(updated.name, 'Petar');
+      expect(updated.avatarUrl, 'url');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Implements #184: a user managing more than one 5kmRun account (most commonly a parent also managing a kid's profile) previously had to sign out and back in to switch accounts. Adds saved, switchable profiles per device, per the issue's agreed design.

### Data model
- **`AuthenticationResource` is rewritten** around a `List<Profile>` + an active-profile pointer, replacing the old single `{userId, token, timestamp}`. `getToken()`/`getUserId()`/`isLoggedIn()` keep their existing meaning (describing the *active* profile) — every pre-existing call site (`home.dart`, settings, offline-chart, both login widgets) works unchanged, no call-site edits needed beyond the two login widgets that now support `addingProfile`.
- **Two profile types**, mirroring the two existing login paths: a **password profile** (keeps a token, needed for Selfie submission) and an **ID-only profile** (no token, view/barcode only — same as today's ID login). A password profile also stores its **email**, which turned out to be necessary: the server authenticates by email, not id, so without it there'd be nothing to re-authenticate an expired token with.
- **Migration**: existing single-account users are migrated silently on first load — the old `key_userId`/`key_token`/`key_tokenTimestamp` keys become a one-item profile list, no forced logout. Verified live (see below).
- **Soft cap of 5 profiles** (`MaxProfilesReachedException`), per the grooming answer.

### Flows
- **Adding a profile reuses the existing Login screen** — `LoginWithUsername`/`LoginWithId` both take an `addingProfile` flag: the new profile is added without disturbing whichever one is active, and success pops back to the switcher instead of replacing the whole nav stack with "home".
- **Switching is instant** unless the target is a password profile with an expired/rejected token, in which case a password prompt (plus an email prompt for a profile migrated pre-#184, which never recorded one) completes the switch.
- **State reset on switch** (`lib/common/profile_switcher.dart`): clears and reloads only **per-user** resources — `UserResource`, `RunsResource`, and the Strava connection. The Strava connection is **disconnected** rather than swapped — `strava_client` keeps its own OAuth session in its own storage with no per-profile keying of its own, so disconnecting is what avoids silently attributing one profile's Strava activities to another. **Device-level settings** (`LocalStorageResource`, `LocalePr...
- **Quick switcher**: the avatar/name on the Profile tab (there's no literal app bar there) opens a bottom sheet — saved profiles, "Add profile", "Manage profiles". Manage Profiles covers add/switch/remove per the acceptance criteria; **reordering is out of scope** (not in the acceptance criteria, and not worth the extra complexity here).
- **Removing a profile** clears its token **locally only** — no server-side invalidation call, per the grooming answer. Removing the active profile falls back to another saved profile, or the login screen if none remain.
- Analytics events for `profile_add`/`profile_switch`/`profile_remove`, each tagged with profile type.

### Two pre-existing bugs found and fixed along the way
Writing tests for the success path surfaced that `LoginWithUsername`'s `FirebaseCrashlytics`/`FirebaseAnalytics` calls on a *successful* login, and `refresh_helper.dart`'s `reportOnFailure`, weren't guarded against a missing Firebase app — a successful login (or any reported failure) could silently misfire into the wrong error branch without one. Both now follow the same best-effort try/catch pattern already used elsewhere in the file.

## Test plan
- New: `test/state/profile_model_test.dart` (11 tests: `isTokenExpired` semantics, JSON round-trip, `copyWith`), `test/state/authentication_resource_test.dart` (16 tests: add/cap/upsert, switch, remove + active-profile fallback, logout, `updateProfileDisplay`, migration from the old single-account keys including an already-expired token), `test/common/profile_switcher_test.dart` (5 tests: switch reloads per-user data and leaves settings untouched, unknown-id switch is a no-op, expired-token p...
- `flutter analyze` (full project): 0 errors, 0 new warnings — the 6 pre-existing warnings are all in unrelated files.
- `flutter test` (full suite): all 257 tests pass, no regressions.
- **Manually verified end-to-end on a booted Android emulator** with a real logged-in session: confirmed the existing single-account session **migrated silently** into a one-profile list (shown correctly as "ID only" in the switcher, checkmarked active) — no forced logout. Opened the switcher from the Profile tab avatar, added a second (ID-only) profile via the reused Login screen, confirmed it appeared in the switcher without disturbing the active one, switched to it and confirmed the profil...

## Manual testing instructions
1. Profile tab → tap the avatar/name → the switcher sheet lists saved profiles, "Add profile", "Manage profiles".
2. Add profile → either tab (username/password or ID) → on success you're back at the switcher with the new profile listed, still on your original active profile.
3. Tap a different profile in the switcher → instant switch, all profile data reloads for the new identity.
4. Manage profiles → delete icon on a row → confirm dialog → removes it (falls back to another profile, or the login screen if it was the last one).
5. Settings (push notifications, language) should be unaffected by any of the above.

Closes #184