### PR TITLE
feat: surface the Wallet pass only on Saturday race hours near a venue

### DIFF
--- a/fivekmrun_app_flutter/ios/Runner.xcodeproj/project.pbxproj
+++ b/fivekmrun_app_flutter/ios/Runner.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		A1B2C3D4E5F600001234AB01 /* WalletPassGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600001234AB00 /* WalletPassGenerator.swift */; };
+		A1B2C3D4E5F600001234AB31 /* RaceVenues.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600001234AB30 /* RaceVenues.swift */; };
 		A1B2C3D4E5F600001234AB03 /* pass_certificate.p12 in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600001234AB02 /* pass_certificate.p12 */; };
 		A1B2C3D4E5F600001234AB21 /* wallet_brand.png in Resources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600001234AB20 /* wallet_brand.png */; };
 		A1B2C3D4E5F600001234AB11 /* PassSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F600001234AB10 /* PassSecrets.swift */; };
@@ -51,6 +52,7 @@
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A1B2C3D4E5F600001234AB00 /* WalletPassGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalletPassGenerator.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F600001234AB30 /* RaceVenues.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RaceVenues.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F600001234AB02 /* pass_certificate.p12 */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.pkcs12; path = pass_certificate.p12; sourceTree = "<group>"; };
 		A1B2C3D4E5F600001234AB20 /* wallet_brand.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = wallet_brand.png; sourceTree = "<group>"; };
 		A1B2C3D4E5F600001234AB10 /* PassSecrets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PassSecrets.swift; sourceTree = "<group>"; };
@@ -124,6 +126,7 @@
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
 				A1B2C3D4E5F600001234AB00 /* WalletPassGenerator.swift */,
+				A1B2C3D4E5F600001234AB30 /* RaceVenues.swift */,
 				A1B2C3D4E5F600001234AB10 /* PassSecrets.swift */,
 				A1B2C3D4E5F600001234AB02 /* pass_certificate.p12 */,
 				A1B2C3D4E5F600001234AB20 /* wallet_brand.png */,
@@ -400,6 +403,7 @@
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
 				A1B2C3D4E5F600001234AB01 /* WalletPassGenerator.swift in Sources */,
+				A1B2C3D4E5F600001234AB31 /* RaceVenues.swift in Sources */,
 				A1B2C3D4E5F600001234AB11 /* PassSecrets.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);

--- a/fivekmrun_app_flutter/ios/Runner/RaceVenues.swift
+++ b/fivekmrun_app_flutter/ios/Runner/RaceVenues.swift
@@ -24,6 +24,25 @@ let raceVenues: [RaceVenue] = [
     // route's own page: https://5kmrun.bg/route/94
     RaceVenue(name: "Южен парк, София", latitude: 42.672028, longitude: 23.307750),
 
+    // Западен парк (West Park), Sofia — https://5kmrun.bg/route/95
+    RaceVenue(name: "Западен парк, София", latitude: 42.708978, longitude: 23.275349),
+
+    // гр. Пловдив, Гребна база (Гребен канал 2) — https://5kmrun.bg/route/99
+    RaceVenue(name: "Гребен канал 2, Пловдив", latitude: 42.146111, longitude: 24.713056),
+
+    // Парк Лаута, Пловдив — https://5kmrun.bg/route/100 (site page has no
+    // text coordinates; taken from its own Google Maps pin instead).
+    // NOTE: Plovdiv has two routes listed on 5kmrun.bg/routes/5km (this one
+    // and Гребен канал 2 above) — both are included since it wasn't
+    // specified which is "the" regular run; remove whichever doesn't apply.
+    RaceVenue(name: "Парк Лаута, Пловдив", latitude: 42.139019, longitude: 24.779428),
+
+    // гр. Бургас, Морска градина (Sea Garden) — https://5kmrun.bg/route/97
+    RaceVenue(name: "Морска градина, Бургас", latitude: 42.500944, longitude: 27.480722),
+
+    // гр. Варна, Морска градина (Sea Garden) — https://5kmrun.bg/route/96
+    RaceVenue(name: "Морска градина, Варна", latitude: 43.205944, longitude: 27.926444),
+
     // Add more venues here, one per line, following the same shape:
     // RaceVenue(name: "<venue name>", latitude: <lat>, longitude: <lon>),
 ]

--- a/fivekmrun_app_flutter/ios/Runner/RaceVenues.swift
+++ b/fivekmrun_app_flutter/ios/Runner/RaceVenues.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Race venues used for the Wallet pass's "relevant location" trigger (#212).
+///
+/// Every 5kmRun Saturday event runs at the same time slot (9:00–12:00) but at
+/// a different place each week, and Apple's pass `locations` array applies to
+/// the *whole* pass rather than to individual `relevantDates` entries — so
+/// there is no way to pair "this Saturday" with "this Saturday's venue"
+/// specifically. The pass ends up relevant on any Saturday morning AND near
+/// *any* of the venues listed here. That's an Apple-side limitation, not a
+/// bug — see #212 for the full writeup.
+///
+/// To add a venue: add one more `RaceVenue(...)` line below. Apple allows at
+/// most 10 locations per pass (`Pass.locations`), so keep this list capped at
+/// 10 entries.
+struct RaceVenue {
+    let name: String
+    let latitude: Double
+    let longitude: Double
+}
+
+let raceVenues: [RaceVenue] = [
+    // Южен парк (South Park), Sofia — start-line coordinates from the
+    // route's own page: https://5kmrun.bg/route/94
+    RaceVenue(name: "Южен парк, София", latitude: 42.672028, longitude: 23.307750),
+
+    // Add more venues here, one per line, following the same shape:
+    // RaceVenue(name: "<venue name>", latitude: <lat>, longitude: <lon>),
+]

--- a/fivekmrun_app_flutter/ios/Runner/WalletPassGenerator.swift
+++ b/fivekmrun_app_flutter/ios/Runner/WalletPassGenerator.swift
@@ -7,11 +7,25 @@ class WalletPassGenerator {
     private static let passTypeIdentifier = "pass.bg.fivekmpark.5kmrun"
     private static let teamIdentifier = "48HKWHQ6FS"
 
+    // #212: how far ahead to pre-populate Saturday relevance windows. Apple
+    // documents no cap on `relevantDates` array length; this is a
+    // conservative starting point pending empirical testing of any real
+    // ceiling (see the issue). At 12 weeks, the pass needs regenerating
+    // (re-tapping "Add to Wallet") roughly every 3 months to keep surfacing —
+    // acceptable since no auto-update was wanted for this feature.
+    private static let relevantWeeksAhead = 12
+
+    // Apple's default geofence radius is an undocumented, adjustable-only-
+    // downward implementation detail. 500m comfortably covers approaching a
+    // park-sized venue on foot or by car without a documented number to rely
+    // on more precisely.
+    private static let maxRelevantDistanceMeters = 500
+
     static func generatePass(userId: Int, userName: String, userStatus: String) throws -> URL {
         let barcodeValue = String(format: "%010d", userId)
         let barcodeFormat = "PKBarcodeFormatCode128"
 
-        let passJSON: [String: Any] = [
+        var passJSON: [String: Any] = [
             "formatVersion": 1,
             "passTypeIdentifier": passTypeIdentifier,
             "serialNumber": "5kmrun-\(userId)",
@@ -45,6 +59,22 @@ class WalletPassGenerator {
             ]
         ]
 
+        // #212: surface the pass on the lock screen only when BOTH a
+        // Saturday 9:00-12:00 window AND proximity to a race venue hold —
+        // documented as AND semantics for `generic`-style passes (this pass
+        // stays `generic` above; `coupon`/`storeCard` ignore dates entirely
+        // and must not be used here). `relevantDates` has no recurrence
+        // primitive, so each upcoming Saturday gets its own explicit entry.
+        passJSON["relevantDates"] = upcomingSaturdayWindows(weeksAhead: relevantWeeksAhead)
+        passJSON["locations"] = raceVenues.map { venue in
+            [
+                "latitude": venue.latitude,
+                "longitude": venue.longitude,
+                "relevantText": "5kmRun \(venue.name) — покажи баркода си"
+            ]
+        }
+        passJSON["maxDistance"] = maxRelevantDistanceMeters
+
         let passData = try JSONSerialization.data(withJSONObject: passJSON, options: .prettyPrinted)
 
         // Brand the pass with the app logo (falls back to a blank pixel if missing).
@@ -63,6 +93,63 @@ class WalletPassGenerator {
         let signature = try signManifest(manifestData: manifestData)
 
         return try buildPassArchive(files: files, manifestData: manifestData, signature: signature)
+    }
+
+    // MARK: - Relevance (#212)
+
+    /// Builds one `Pass.RelevantDates` entry per upcoming Saturday's
+    /// 9:00-12:00 window, `weeksAhead` weeks out starting from (and
+    /// including, if today is a Saturday) today. Each entry's UTC offset is
+    /// computed per-date against Europe/Sofia so the EET/EEST DST switch
+    /// doesn't shift the wall-clock 9:00/12:00 window.
+    private static func upcomingSaturdayWindows(weeksAhead: Int) -> [[String: String]] {
+        guard let sofiaTimeZone = TimeZone(identifier: "Europe/Sofia") else { return [] }
+
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = sofiaTimeZone
+
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = sofiaTimeZone
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZZZZZ"
+
+        // Walk forward by whole days (not exact instants) so a Saturday
+        // afternoon "now" still counts today as this week's Saturday, rather
+        // than skipping to next week because the loop compared instants.
+        var candidateDay = calendar.startOfDay(for: Date())
+        while calendar.component(.weekday, from: candidateDay) != 7 { // 7 = Saturday
+            guard let nextDay = calendar.date(byAdding: .day, value: 1, to: candidateDay) else {
+                return []
+            }
+            candidateDay = nextDay
+        }
+
+        var windows: [[String: String]] = []
+        for week in 0..<weeksAhead {
+            guard let saturday = calendar.date(byAdding: .day, value: week * 7, to: candidateDay)
+            else { continue }
+
+            let dayComponents = calendar.dateComponents([.year, .month, .day], from: saturday)
+
+            var startComponents = dayComponents
+            startComponents.hour = 9
+            startComponents.minute = 0
+            startComponents.second = 0
+
+            var endComponents = dayComponents
+            endComponents.hour = 12
+            endComponents.minute = 0
+            endComponents.second = 0
+
+            guard let start = calendar.date(from: startComponents),
+                  let end = calendar.date(from: endComponents) else { continue }
+
+            windows.append([
+                "startDate": formatter.string(from: start),
+                "endDate": formatter.string(from: end)
+            ])
+        }
+        return windows
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary
Implements #212 (Apple side, per the product decision — Google Wallet is explicitly out of scope here). The runner-ID Wallet pass never auto-surfaced on the lock screen before this — a runner had to remember to open Wallet manually at check-in. Now it surfaces automatically only when **both** hold at once:
1. A recurring **Saturday 9:00–12:00** window, and
2. Proximity to one of the listed **race venues**.

## Why AND, and why `generic`
Apple's Wallet Developer Guide (Table 4-2, "Relevance information for each pass style") documents `locations` + `relevantDate(s)` as combining with **AND** semantics specifically for `generic`, `eventTicket`, and `boardingPass` styles. This pass stays `generic` (unchanged). **`coupon`/`storeCard` styles ignore relevantDate entirely** and would surface on location alone any day of the week — the one style choice that would silently break the AND requirement, so it's called out directly in a co...

Caveat carried into the code comments: that AND rule is only documented in a 2018-archived guide page, never restated for the iOS 18 `relevantDates` (plural) rewrite that replaced the old singular `relevantDate`. No newer Apple source contradicts it, but real device verification (not just Simulator, which doesn't exercise lock-screen relevance) is worth doing before the next release ships.

## What changed
- **`ios/Runner/WalletPassGenerator.swift`**: adds `locations` (+ `maxDistance`, capped-downward-only per Apple's docs, set to 500m) and `relevantDates` to the existing `pass.json` construction. Since `relevantDates` has no recurrence primitive at all, a new `upcomingSaturdayWindows(weeksAhead:)` helper pre-populates one explicit `{startDate, endDate}` entry per upcoming Saturday, 12 weeks ahead — each computed against the `Europe/Sofia` time zone so the EET/EEST DST switch doesn't shift the ...
- **`ios/Runner/RaceVenues.swift`** (new): a small, obviously-editable list of venues. Stubbed with **Южен парк (South Park), Sofia** — start-line coordinates taken from the route's own page (https://5kmrun.bg/route/94: N 42°40'19.3", E 023°18'27.9" → 42.672028, 23.307750). Adding another venue is one line; a comment notes Apple's 10-location cap on `Pass.locations`.
- Xcode project file updated to compile the new source file.

Per your answers on #212: **all events run at the same 9–12 slot but at different venues each week**. Apple's `locations` array applies to the whole pass, not to individual `relevantDates` entries, so the AND we get is "any Saturday morning AND near **any** listed venue" — which is exactly what "different place each week, same time slot" needs; there's no way (or need) to pair a specific Saturday with a specific venue.

## No auto-update, by design
Per #212, times/venues are static — there's no push-update web service here. The pass simply needs regenerating (re-tapping "Add to Wallet") roughly every ~12 weeks to keep its `relevantDates` window current, which is an accepted tradeoff, not an oversight.

## Test plan
This repo has **no native XCTest target at all** — the entire PassKit signing/pass-generation code has never had test coverage, pre-existing this change. Verified instead by:
1. **A standalone `swift` script** exercising `upcomingSaturdayWindows`'s exact logic against 5 scenarios: a plain winter weekday, a Saturday morning *before* its own window (must still include today), a Saturday afternoon *after* its own window (must still include today, not skip to next week), a summer weekday (checks the `+03:00` EEST offset), and the two Saturdays straddling the actual 2026 spring-forward DST transition (checks `+02:00` → `+03:00` flips correctly). All 5 produced the expe...
2. **`swiftc -typecheck`** against the `iphonesimulator` SDK, using the project's own bridging header (for the pre-existing `CommonCrypto` calls) — 0 errors on the full modified file plus the new one.
3. **A real `flutter build ios --no-codesign --simulator`**: Xcode compiled every source file successfully ("Xcode build done", ~60s) — it only failed afterward at the resource-copy step because `pass_certificate.p12` (a CI-injected secret) isn't present on this dev machine. That's the same pre-existing, unrelated environment gap noted on earlier PRs against this repo, not something this change touches.

## Manual testing instructions (once built with real signing secrets)
1. Generate a pass via the app's "Add to Apple Wallet" button.
2. Inspect the resulting `pass.json` inside the `.pkpass` (it's a zip) — confirm `locations` has the Южен парк entry and `relevantDates` has ~12 upcoming Saturday windows with correct offsets.
3. On a real device (Simulator doesn't exercise this), confirm the pass surfaces on the lock screen only when both near a listed venue AND within a Saturday 9–12 window — not on location alone, not on time alone.

Closes #212