### PR TITLE
test: add coverage for PinkishRedColor palette/shade math

### DIFF
--- a/fivekmrun_app_flutter/test/common/pinkish_red_palette_test.dart
+++ b/fivekmrun_app_flutter/test/common/pinkish_red_palette_test.dart
@@ -1,0 +1,83 @@
+import 'package:fivekmrun_flutter/common/pinkish_red_palette.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('PinkishRedColor', () {
+    test('has the documented #FC1851 base color', () {
+      final color = PinkishRedColor();
+      expect(color.r, 252);
+      expect(color.g, 24);
+      expect(color.b, 81);
+      expect(color.hexString, '#fc1851');
+    });
+  });
+
+  group('PinkishRedColor.getPalette', () {
+    test('returns the fixed set of dark-to-light hex shades', () {
+      final palette = PinkishRedColor().getPalette();
+
+      expect(palette.map((c) => c.hexString), [
+        '#560000',
+        '#880000',
+        '#c10029',
+        '#fb4d52',
+        '#ff827e',
+      ]);
+    });
+  });
+
+  group('PinkishRedColor.makeShades', () {
+    test('always starts with the base color and ends back at it', () {
+      final base = PinkishRedColor();
+
+      for (final count in [1, 2, 3, 5]) {
+        final shades = base.makeShades(count);
+        expect(shades.length, count + 1,
+            reason: 'makeShades($count) should return $count + 1 colors');
+        expect(shades.first, base);
+        expect(shades.last, base);
+      }
+    });
+
+    test('the single computed shade for count 2 lightens exactly halfway',
+        () {
+      // steps = 2, fraction = 1/2 — exact enough to hand-verify:
+      // r: 252 + (255-252)*0.5 = 253.5 -> 254 (round half away from zero)
+      // g: 24  + (255-24)*0.5  = 139.5 -> 140
+      // b: 81  + (255-81)*0.5  = 168 (exact)
+      final shades = PinkishRedColor().makeShades(2);
+
+      expect(shades[1].r, 254);
+      expect(shades[1].g, 140);
+      expect(shades[1].b, 168);
+    });
+
+    test('interpolated shades lighten monotonically towards white', () {
+      final shades = PinkishRedColor().makeShades(4);
+      // shades[0] is the base color, shades[4] is the base color again;
+      // shades[1..3] are the interpolated steps in between.
+      final steps = shades.sublist(1, shades.length - 1);
+
+      for (var i = 1; i < steps.length; i++) {
+        expect(steps[i].r, greaterThanOrEqualTo(steps[i - 1].r));
+        expect(steps[i].g, greaterThanOrEqualTo(steps[i - 1].g));
+        expect(steps[i].b, greaterThanOrEqualTo(steps[i - 1].b));
+      }
+
+      // Every step lightened relative to the base color.
+      final base = PinkishRedColor();
+      for (final step in steps) {
+        expect(step.r, greaterThanOrEqualTo(base.r));
+        expect(step.g, greaterThanOrEqualTo(base.g));
+        expect(step.b, greaterThanOrEqualTo(base.b));
+      }
+    });
+
+    test('keeps full alpha throughout', () {
+      final shades = PinkishRedColor().makeShades(3);
+      for (final shade in shades) {
+        expect(shade.a, 255);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Fallback test-coverage work: all three open `up-for-claude` issues (#212, #188, #187) already have open PRs against them (#213, #192, #196 respectively), so per the nightly-task convention this run added test coverage for an untested module instead.

`lib/common/pinkish_red_palette.dart` (`PinkishRedColor`) had no test file. It's a good fit for the fallback because, unlike most of the remaining untested files (widgets, Firebase/platform-channel wrappers), it contains real, self-contained numeric logic with no platform dependency:
- `makeShades(colorCnt)` — builds a list of interpolated colors stepping from the base pink toward white, private `_getSteppedColor` helper does linear-interpolation-with-rounding
- `getPalette()` — a fixed list of hex shades used for chart series

## What's covered
- `PinkishRedColor()`'s base RGB/hex value (`#FC1851`)
- `getPalette()`'s exact fixed hex output
- `makeShades(n)`'s structural invariant: always `n + 1` colors, starting and ending on the base color
- An exact hand-verified value check for `makeShades(2)`'s single interpolated midpoint (steps=2, fraction=0.5, verified Dart's round-half-away-from-zero behavior for the two half-integer components)
- Monotonic lightening of the interpolated steps for `makeShades(4)`, and that every step is lighter than or equal to the base color
- Alpha stays at 255 throughout

## Test plan
- `flutter analyze test/common/pinkish_red_palette_test.dart` — no issues found
- `flutter test test/common/pinkish_red_palette_test.dart` — 6/6 passed
- `flutter test` (full suite) — 315/315 passed, exit code 0

No app run/screenshot verification needed — this PR only adds unit tests for a pure, non-UI helper class; there's no user-facing behavior to exercise in the simulator.