### PR TITLE
fix: show selfie runs when the official endpoint has no history

### DIFF
--- a/fivekmrun_app_flutter/lib/state/runs_resource.dart
+++ b/fivekmrun_app_flutter/lib/state/runs_resource.dart
@@ -5,6 +5,15 @@ import 'package:http/http.dart' as http;
 import 'package:fivekmrun_flutter/constants.dart' as constants;
 import 'dart:convert';
 
+/// The outcome of loading one run source: the runs it returned, or the error
+/// that stopped it. Exactly one of the two is meaningful.
+class _SourceResult {
+  final List<Run> runs;
+  final Object? failure;
+
+  const _SourceResult(this.runs, this.failure);
+}
+
 class RunsResource extends ChangeNotifier {
   /// Injectable for tests; defaults to a real client in production.
   final http.Client _client;
@@ -52,33 +61,62 @@ class RunsResource extends ChangeNotifier {
     this._lastOfficialRun = null;
   }
 
-  /// Fetches the user's runs and replaces [value] on success.
+  /// Fetches the user's runs from each source and replaces [value].
   ///
-  /// If the fetch fails the previously loaded runs are kept — an unreachable
-  /// server must not look the same as "this user has never run". The error is
-  /// rethrown so callers can react; see [refreshAllData].
+  /// The sources are independent. `5kmrun/user/<id>` does not answer with an
+  /// empty array for a user with no official results — it errors server-side
+  /// and redirects to an HTML page. Loading them in one `try` meant that page
+  /// aborted the whole load, so every user whose history is selfie-only saw an
+  /// empty runs list despite having hundreds of runs. A source that fails now
+  /// contributes nothing and the others still load.
+  ///
+  /// If *every* source fails the previously loaded runs are kept and the error
+  /// is rethrown — an unreachable server must not look the same as "this user
+  /// has never run". See [refreshAllData].
+  ///
+  /// A partial failure does replace [value] with what did load, so a source
+  /// that is down drops its runs from the list until the next refresh. That is
+  /// deliberate: showing the rest beats showing nothing, and it self-heals.
   Future<List<Run>> getByUserId(int? userId) async {
     if (userId == null) {
       return this.value ?? <Run>[];
     }
 
-    final List<Run> runs;
-    try {
-      runs = await this.retrieve5kmRuns(userId);
-      final List<Run> selfieRuns = await this.retrieveSelfieRuns(userId);
-      runs.addAll(selfieRuns.where((r) => r.timeInSeconds != null));
-      final List<Run> xlRuns = await this.retrieveXLRuns(userId);
-      runs.addAll(xlRuns.where((r) => r.timeInSeconds != null));
-    } catch (_) {
+    final official = await _tryRetrieve(() => this.retrieve5kmRuns(userId));
+    final selfie = await _tryRetrieve(() => this.retrieveSelfieRuns(userId));
+    final xl = await _tryRetrieve(() => this.retrieveXLRuns(userId));
+
+    // Only the two mandatory sources decide this. [retrieveXLRuns] already
+    // answers "no XL runs" for its own error page, so it succeeds with an
+    // empty list for nearly every user — letting it vote here would mean a
+    // total outage of the other two still looked like "no runs".
+    if (official.failure != null && selfie.failure != null) {
       this.loading = false;
-      rethrow;
+      throw official.failure!;
     }
+
+    final List<Run> runs = <Run>[
+      ...official.runs,
+      ...selfie.runs.where((r) => r.timeInSeconds != null),
+      ...xl.runs.where((r) => r.timeInSeconds != null),
+    ];
 
     this._processRuns(runs);
 
     this.value = runs;
     this.loading = false;
     return runs;
+  }
+
+  /// Runs [retrieve], turning a failure into an empty result that records the
+  /// error instead of propagating it.
+  Future<_SourceResult> _tryRetrieve(
+      Future<List<Run>> Function() retrieve) async {
+    try {
+      return _SourceResult(await retrieve(), null);
+    } catch (error) {
+      return _SourceResult(const <Run>[], error);
+    }
   }
 
   Future<List<Run>> retrieve5kmRuns(int? userId) async {

--- a/fivekmrun_app_flutter/test/state/runs_resource_test.dart
+++ b/fivekmrun_app_flutter/test/state/runs_resource_test.dart
@@ -52,7 +52,11 @@ final _xl = {
 /// gives most users (see [RunsResource.retrieveXLRuns]) so existing
 /// official/selfie-only assertions don't need to account for an XL run
 /// they didn't ask for.
-MockClient _client({int selfieStatus = 200, http.Response? xlResponse}) =>
+MockClient _client({
+  int selfieStatus = 200,
+  http.Response? xlResponse,
+  http.Response? officialResponse,
+}) =>
     MockClient((request) async {
       if (request.url.path.contains("selfie")) {
         return http.Response(jsonEncode(_selfie), selfieStatus,
@@ -63,8 +67,20 @@ MockClient _client({int selfieStatus = 200, http.Response? xlResponse}) =>
             http.Response("<html>not found</html>", 200,
                 headers: {"content-type": "text/html; charset=utf-8"});
       }
-      return http.Response(jsonEncode(_official), 200, headers: _jsonHeaders);
+      return officialResponse ??
+          http.Response(jsonEncode(_official), 200, headers: _jsonHeaders);
     });
+
+/// What `5kmrun/user/<id>` actually answers for a user with no official
+/// results: it errors server-side and redirects to an article page, so the
+/// client sees 200 text/html rather than an empty array.
+final _officialNoHistoryPage = http.Response(
+  "<br /> <b>Notice</b>:  Undefined offset: 0 in "
+  "<b>/home/kmrunbg/appCore/classes/Logic/Pub/Petkmrun/ApiUser.php</b> "
+  "on line <b>132</b><br />",
+  200,
+  headers: {"content-type": "text/html; charset=utf-8"},
+);
 
 void main() {
   group('RunsResource.getByUserId', () {
@@ -93,13 +109,46 @@ void main() {
       expect(called, isFalse);
     });
 
-    test('rethrows FetchException and stops loading when a fetch fails',
-        () async {
-      final resource = RunsResource(client: _client(selfieStatus: 500));
+    test(
+        'rethrows FetchException and stops loading when every source fails, '
+        'so a server outage never looks like "no runs"', () async {
+      final resource = RunsResource(
+          client: _client(
+              selfieStatus: 500,
+              officialResponse: http.Response("server error", 500)));
 
       await expectLater(
           resource.getByUserId(42), throwsA(isA<FetchException>()));
       expect(resource.loading, isFalse);
+      expect(resource.value, isNull);
+    });
+
+    test(
+        'keeps the selfie runs when the official endpoint serves its '
+        'no-history error page', () async {
+      // The reported bug: users with no official results (IDs 24342, 22237,
+      // 33679) saw an empty list despite hundreds of selfie runs, because the
+      // official endpoint's HTML error page aborted the whole load.
+      final resource =
+          RunsResource(client: _client(officialResponse: _officialNoHistoryPage));
+
+      final runs = await resource.getByUserId(24342);
+
+      expect(runs, hasLength(1));
+      expect(runs.single.runType, RunType.selfie);
+      expect(resource.lastSelfieRun, isNotNull);
+      expect(resource.loading, isFalse);
+    });
+
+    test('still returns official runs when only the selfie source fails',
+        () async {
+      final resource = RunsResource(client: _client(selfieStatus: 500));
+
+      final runs = await resource.getByUserId(42);
+
+      expect(runs, hasLength(1));
+      expect(runs.single.runType, RunType.official);
+      expect(resource.lastOfficialRun, isNotNull);
     });
 
     test('merges XL runs in when the endpoint answers with JSON', () async {


### PR DESCRIPTION
Cherry-pick of the v3.18.1 patch onto `master`.

## The bug

`GET https://5kmrun.bg/api/5kmrun/user/<id>` does not return an empty array for a user with no official 5km results. It errors server-side and redirects to an article page:

```
HTTP/1.1 302 Found → https://5kmrun.bg/read/176
Content-Type: text/html; charset=UTF-8
Notice: Undefined offset: 0 in .../Logic/Pub/Petkmrun/ApiUser.php on line 132
```

`getByUserId` loaded all sources inside one `try`, so that HTML page aborted the entire load. Every user whose history is selfie-only saw an **empty runs list** — and because all three callers wrap the call in `reportOnFailure`, the exception was swallowed, so no error appeared either.

Confirmed against the live API for the three reported accounts:

| User | official endpoint | selfie runs |
|---|---|---|
| 24342 | 302 → HTML | 203 |
| 22237 | 302 → HTML | 165 |
| 33679 | 302 → HTML | 84 |

Regression introduced in 2ff0346, first released in v3.18.0. The prior code returned `[]` on a non-JSON response, so selfie runs still loaded.

Scope is wider than the selfie-only cohort: any non-200-or-non-JSON response from a mandatory source (transient 5xx, maintenance page, rate limit) blanked the whole list for *every* user.

## The fix

Sources load independently — one that fails contributes nothing, the rest still load. Only a failure of both mandatory sources rethrows, preserving the "an unreachable server must not look like *this user has never run*" guarantee.

`retrieveXLRuns` is deliberately excluded from that decision: it already reports its own error page as "no XL runs", so it succeeds for nearly every user and would mask a real outage of the other two.

## Verification

Test-first per CLAUDE.md: the regression tests fail on the pre-fix code with `FetchException: could not load 5km runs (status 200, content-type text/html)` and pass after. The pre-existing test that asserted a single-source failure rethrows encoded the buggy behaviour — it now fails *both* mandatory sources, keeping the outage guarantee under test.

Also verified on the iOS simulator: user 24342 renders **Димитър Апостолов, 203/300** with last/best selfie and the trend chart populated, and the runtime log shows zero `FetchException`.

Full suite passes; no new analyzer issues.

## Differences from the v3.18.1 commit

- XL runs folded into the same independent-source handling (master-only code)
- Regression tests added to the existing `test/state/runs_resource_test.dart` instead of a new file
- No pubspec version bump — master's version is set by the release process

## Server-side follow-up

The root cause is still unfixed on the server. `Petkmrun/ApiUser.php` (lines 132/143/145) and `Xlrun/ApiUser.php` (line 128) index the result set at `[0]` without an empty check. They should return `200` with `{"runners":[]}`, matching what `selfie/user/<id>` already does correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)