### PR TITLE
fix: opt in to edge-to-edge and protect insets on root-level pages

### DIFF
--- a/fivekmrun_app_flutter/lib/barcode_page.dart
+++ b/fivekmrun_app_flutter/lib/barcode_page.dart
@@ -136,93 +136,96 @@ class _BarcodePageState extends State<BarcodePage> {
       }
 
       return Scaffold(
-          appBar: AppBar(
-            leading: BackButton(color: Colors.white),
-            title: Text(AppLocalizations.of(context)!.barcode_page_barcode),
-            centerTitle: true,
-          ),
-          backgroundColor: Colors.black,
-          body: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Center(
-                child: Card(
-              elevation: 8,
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(16),
-              ),
-              child: Container(
-                decoration: BoxDecoration(
+        appBar: AppBar(
+          leading: BackButton(color: Colors.white),
+          title: Text(AppLocalizations.of(context)!.barcode_page_barcode),
+          centerTitle: true,
+        ),
+        backgroundColor: Colors.black,
+        body: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Center(
+                  child: Card(
+                elevation: 8,
+                shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(16),
-                  gradient: LinearGradient(
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                    colors: [
-                      accentColor,
-                      accentColor.withOpacity(0.8),
-                    ],
+                ),
+                child: Container(
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(16),
+                    gradient: LinearGradient(
+                      begin: Alignment.topLeft,
+                      end: Alignment.bottomRight,
+                      colors: [
+                        accentColor,
+                        accentColor.withOpacity(0.8),
+                      ],
+                    ),
+                  ),
+                  child: Padding(
+                    padding: const EdgeInsets.all(24.0),
+                    child: Column(
+                      mainAxisSize: MainAxisSize.min,
+                      children: <Widget>[
+                        Text(
+                          "5kmrun",
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 24,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        SizedBox(height: 8),
+                        Text(
+                          userName!,
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 20,
+                          ),
+                        ),
+                        SizedBox(height: 4),
+                        Text(
+                          userStatus,
+                          style: TextStyle(
+                            color: Colors.white.withOpacity(0.8),
+                            fontSize: 16,
+                          ),
+                        ),
+                        SizedBox(height: 24),
+                        Container(
+                          padding:
+                              EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                          decoration: BoxDecoration(
+                            color: Colors.white,
+                            borderRadius: BorderRadius.circular(8),
+                          ),
+                          child: BarCodeImage(
+                              params: Code39BarCodeParams(
+                            formatBarcode(userId),
+                            lineWidth: 1.5,
+                            barHeight: 60.0,
+                            withText: false,
+                          )),
+                        ),
+                        SizedBox(height: 8),
+                        Text(
+                          userId.toString(),
+                          style: TextStyle(
+                            color: Colors.white,
+                            fontSize: 16,
+                          ),
+                        ),
+                        SizedBox(height: 24),
+                        buildButton(),
+                      ],
+                    ),
                   ),
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.all(24.0),
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: <Widget>[
-                      Text(
-                        "5kmrun",
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 24,
-                          fontWeight: FontWeight.bold,
-                        ),
-                      ),
-                      SizedBox(height: 8),
-                      Text(
-                        userName!,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 20,
-                        ),
-                      ),
-                      SizedBox(height: 4),
-                      Text(
-                        userStatus,
-                        style: TextStyle(
-                          color: Colors.white.withOpacity(0.8),
-                          fontSize: 16,
-                        ),
-                      ),
-                      SizedBox(height: 24),
-                      Container(
-                        padding:
-                            EdgeInsets.symmetric(horizontal: 12, vertical: 8),
-                        decoration: BoxDecoration(
-                          color: Colors.white,
-                          borderRadius: BorderRadius.circular(8),
-                        ),
-                        child: BarCodeImage(
-                            params: Code39BarCodeParams(
-                          formatBarcode(userId),
-                          lineWidth: 1.5,
-                          barHeight: 60.0,
-                          withText: false,
-                        )),
-                      ),
-                      SizedBox(height: 8),
-                      Text(
-                        userId.toString(),
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                        ),
-                      ),
-                      SizedBox(height: 24),
-                      buildButton(),
-                    ],
-                  ),
-                ),
-              ),
+              )),
             )),
-          ));
+      );
     });
   }
 

--- a/fivekmrun_app_flutter/lib/main.dart
+++ b/fivekmrun_app_flutter/lib/main.dart
@@ -17,6 +17,7 @@ import 'package:fivekmrun_flutter/state/runs_resource.dart';
 import 'package:fivekmrun_flutter/state/strava_resource.dart';
 import 'package:fivekmrun_flutter/state/user_resource.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:fivekmrun_flutter/l10n/app_localizations.dart';
 import 'package:fivekmrun_flutter/state/locale_provider.dart';
@@ -29,6 +30,20 @@ final appAccentColor = Color.fromRGBO(218, 3, 56, 1.0);
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Opt in explicitly instead of relying on Android 15+ enforcement. Icons
+  // are always light because the app is permanently in dark theme (see
+  // themeMode: ThemeMode.dark below) regardless of the device setting.
+  SystemChrome.setEnabledSystemUIMode(SystemUiMode.edgeToEdge);
+  SystemChrome.setSystemUIOverlayStyle(const SystemUiOverlayStyle(
+    statusBarColor: Colors.transparent,
+    statusBarIconBrightness: Brightness.light,
+    statusBarBrightness: Brightness.dark,
+    systemNavigationBarColor: Colors.transparent,
+    systemNavigationBarIconBrightness: Brightness.light,
+    systemNavigationBarDividerColor: Colors.transparent,
+  ));
+
   await Firebase.initializeApp();
 
   await FirebaseCrashlytics.instance.setCrashlyticsCollectionEnabled(true);

--- a/fivekmrun_app_flutter/lib/manage_profiles_page.dart
+++ b/fivekmrun_app_flutter/lib/manage_profiles_page.dart
@@ -51,31 +51,34 @@ class ManageProfilesPage extends StatelessWidget {
         title: Text(l10n.profile_switcher_manage_profiles),
         centerTitle: true,
       ),
-      body: ListView(
-        children: <Widget>[
-          for (final profile in authRes.profiles)
-            ListTile(
-              leading: CircleAvatar(
-                backgroundImage: profile.avatarUrl.isNotEmpty
-                    ? NetworkImage(profile.avatarUrl)
-                    : null,
-                child:
-                    profile.avatarUrl.isEmpty ? const Icon(Icons.person) : null,
-              ),
-              title: Text(profile.name.isNotEmpty
-                  ? profile.name
-                  : profile.userId.toString()),
-              subtitle: Text(profile.type == ProfileType.password
-                  ? l10n.profile_switcher_type_password
-                  : l10n.profile_switcher_type_id_only),
-              trailing: IconButton(
-                icon: const Icon(Icons.delete_outline),
-                onPressed: () => _confirmAndRemove(context, profile, l10n),
-              ),
-              selected: profile.userId == activeId,
-            ),
-        ],
-      ),
+      body: SafeArea(
+          top: false,
+          child: ListView(
+            children: <Widget>[
+              for (final profile in authRes.profiles)
+                ListTile(
+                  leading: CircleAvatar(
+                    backgroundImage: profile.avatarUrl.isNotEmpty
+                        ? NetworkImage(profile.avatarUrl)
+                        : null,
+                    child: profile.avatarUrl.isEmpty
+                        ? const Icon(Icons.person)
+                        : null,
+                  ),
+                  title: Text(profile.name.isNotEmpty
+                      ? profile.name
+                      : profile.userId.toString()),
+                  subtitle: Text(profile.type == ProfileType.password
+                      ? l10n.profile_switcher_type_password
+                      : l10n.profile_switcher_type_id_only),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete_outline),
+                    onPressed: () => _confirmAndRemove(context, profile, l10n),
+                  ),
+                  selected: profile.userId == activeId,
+                ),
+            ],
+          )),
     );
   }
 }

--- a/fivekmrun_app_flutter/lib/settings_page.dart
+++ b/fivekmrun_app_flutter/lib/settings_page.dart
@@ -59,72 +59,77 @@ class _SettingsPageState extends State<SettingsPage> {
           title: Text(AppLocalizations.of(context)!.settings_page_settings),
           centerTitle: true,
         ),
-        body: Padding(
-          padding: const EdgeInsets.all(12.0),
-          child: Column(children: <Widget>[
-            Row(
-              children: <Widget>[
-                Text(AppLocalizations.of(context)!.settings_page_notifications),
-                Switch(
-                  onChanged: (value) {
-                    final pushNotificationManager =
-                        PushNotificationsManager.getInstance();
-                    setState(() => localStorage.isSubscrubedForGeneral = value);
-                    this._pushNotificationsSubscribed = value;
-                    if (value) {
-                      pushNotificationManager.subscribeTopic("general");
-                    } else {
-                      pushNotificationManager.unsubscribeTopic("general");
-                    }
+        body: SafeArea(
+            top: false,
+            child: Padding(
+              padding: const EdgeInsets.all(12.0),
+              child: Column(children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Text(AppLocalizations.of(context)!
+                        .settings_page_notifications),
+                    Switch(
+                      onChanged: (value) {
+                        final pushNotificationManager =
+                            PushNotificationsManager.getInstance();
+                        setState(
+                            () => localStorage.isSubscrubedForGeneral = value);
+                        this._pushNotificationsSubscribed = value;
+                        if (value) {
+                          pushNotificationManager.subscribeTopic("general");
+                        } else {
+                          pushNotificationManager.unsubscribeTopic("general");
+                        }
+                      },
+                      value: this._pushNotificationsSubscribed,
+                    )
+                  ],
+                ),
+                Divider(color: dividerColor),
+                Text(AppLocalizations.of(context)!.settings_page_strava),
+                StravaConnect(),
+                Divider(color: dividerColor),
+                Row(
+                  children: <Widget>[
+                    Text(AppLocalizations.of(context)!.settings_page_language),
+                    SizedBox(width: 12),
+                    LocaleSwitcherWidget(),
+                  ],
+                ),
+                Divider(color: dividerColor),
+                InkWell(
+                  onTap: () => Navigator.of(context, rootNavigator: true)
+                      .push(MaterialPageRoute(builder: (_) => WhatsNewPage())),
+                  child: Row(
+                    children: <Widget>[
+                      Text(AppLocalizations.of(context)!
+                          .settings_page_whats_new),
+                      Spacer(),
+                      Icon(Icons.chevron_right),
+                    ],
+                  ),
+                ),
+                Divider(color: dividerColor),
+                Row(children: <Widget>[
+                  Text(AppLocalizations.of(context)!.settings_page_exit),
+                  IconButton(
+                    icon: const Icon(Icons.exit_to_app),
+                    onPressed: logout,
+                  ),
+                ]),
+                Divider(color: dividerColor),
+                FutureBuilder<PackageInfo>(
+                  future: PackageInfo.fromPlatform(),
+                  builder: (context, snapshot) {
+                    if (!snapshot.hasData) return const SizedBox.shrink();
+                    return Text(
+                      AppLocalizations.of(context)!
+                          .settings_page_version(snapshot.data!.version),
+                      style: Theme.of(context).textTheme.bodySmall,
+                    );
                   },
-                  value: this._pushNotificationsSubscribed,
-                )
-              ],
-            ),
-            Divider(color: dividerColor),
-            Text(AppLocalizations.of(context)!.settings_page_strava),
-            StravaConnect(),
-            Divider(color: dividerColor),
-            Row(
-              children: <Widget>[
-                Text(AppLocalizations.of(context)!.settings_page_language),
-                SizedBox(width: 12),
-                LocaleSwitcherWidget(),
-              ],
-            ),
-            Divider(color: dividerColor),
-            InkWell(
-              onTap: () => Navigator.of(context, rootNavigator: true)
-                  .push(MaterialPageRoute(builder: (_) => WhatsNewPage())),
-              child: Row(
-                children: <Widget>[
-                  Text(AppLocalizations.of(context)!.settings_page_whats_new),
-                  Spacer(),
-                  Icon(Icons.chevron_right),
-                ],
-              ),
-            ),
-            Divider(color: dividerColor),
-            Row(children: <Widget>[
-              Text(AppLocalizations.of(context)!.settings_page_exit),
-              IconButton(
-                icon: const Icon(Icons.exit_to_app),
-                onPressed: logout,
-              ),
-            ]),
-            Divider(color: dividerColor),
-            FutureBuilder<PackageInfo>(
-              future: PackageInfo.fromPlatform(),
-              builder: (context, snapshot) {
-                if (!snapshot.hasData) return const SizedBox.shrink();
-                return Text(
-                  AppLocalizations.of(context)!
-                      .settings_page_version(snapshot.data!.version),
-                  style: Theme.of(context).textTheme.bodySmall,
-                );
-              },
-            ),
-          ]),
-        ));
+                ),
+              ]),
+            )));
   }
 }

--- a/fivekmrun_app_flutter/lib/whats_new/whats_new_page.dart
+++ b/fivekmrun_app_flutter/lib/whats_new/whats_new_page.dart
@@ -62,40 +62,43 @@ class _WhatsNewPageState extends State<WhatsNewPage> {
         title: Text(l10n.whats_new_page_title),
         centerTitle: true,
       ),
-      body: _loading
-          ? Center(child: CircularProgressIndicator())
-          : ListView(
-              padding: const EdgeInsets.all(16.0),
-              children: <Widget>[
-                if (_currentVersion != null)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 16.0),
-                    child: Text(
-                      l10n.whats_new_page_current_version(_currentVersion!),
-                      style: Theme.of(context).textTheme.bodyMedium,
+      body: SafeArea(
+        top: false,
+        child: _loading
+            ? Center(child: CircularProgressIndicator())
+            : ListView(
+                padding: const EdgeInsets.all(16.0),
+                children: <Widget>[
+                  if (_currentVersion != null)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 16.0),
+                      child: Text(
+                        l10n.whats_new_page_current_version(_currentVersion!),
+                        style: Theme.of(context).textTheme.bodyMedium,
+                      ),
                     ),
-                  ),
-                for (final entry in widget.resource.recentEntries)
-                  Padding(
-                    padding: const EdgeInsets.only(bottom: 24.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: <Widget>[
-                        Text(
-                          entry.version,
-                          style: Theme.of(context).textTheme.titleLarge,
-                        ),
-                        const SizedBox(height: 8),
-                        for (final bullet in entry.bulletsFor(localeCode))
-                          Padding(
-                            padding: const EdgeInsets.only(bottom: 4.0),
-                            child: Text("• $bullet"),
+                  for (final entry in widget.resource.recentEntries)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 24.0),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: <Widget>[
+                          Text(
+                            entry.version,
+                            style: Theme.of(context).textTheme.titleLarge,
                           ),
-                      ],
+                          const SizedBox(height: 8),
+                          for (final bullet in entry.bulletsFor(localeCode))
+                            Padding(
+                              padding: const EdgeInsets.only(bottom: 4.0),
+                              child: Text("• $bullet"),
+                            ),
+                        ],
+                      ),
                     ),
-                  ),
-              ],
-            ),
+                ],
+              ),
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary

Google Play Console flagged **release 3.18.1** under *User experience*: "Edge-to-edge may not display for all users" — from Android 15 (API 35), apps targeting SDK 35+ (we target 36) get edge-to-edge enforced, and we'd never explicitly opted in or handled insets.

- Explicitly enables edge-to-edge in `main()` via `SystemChrome.setEnabledSystemUIMode`/`setSystemUIOverlayStyle`, with transparent system bars and always-light icons (the app is permanently in dark theme — `themeMode: ThemeMode.dark` — regardless of the device setting, so there's no light-theme case to handle).
- Wraps the `body` of the four Scaffolds reached via the **root** Navigator — `barcode_page.dart`, `settings_page.dart`, `manage_profiles_page.dart`, `whats_new_page.dart` — in a bottom `SafeArea`. These are the pages that see the full, unconsumed bottom system inset.
- Left everything nested under `Home`'s tab navigator alone: their bottom inset is already consumed by the `bottomNavigationBar` (Scaffold zeroes it out for nested content once a bottom nav bar is present), and `ProfileDashboard` already handles its own top inset via `ColorfulSafeArea` — both already correct, no drift to `SafeArea` needed.

No new dependencies added (`colorful_safe_area` is kept as-is — it already does the job).

## Why these four pages specifically

Every other page with a `Scaffold` either has an `AppBar` (handles the top inset by layout, not by MediaQuery) and lives nested inside Home's `TabNavigator`, or is `login.dart`/`loginPreview.dart` which already wraps `body` in `SafeArea`. The four touched here are pushed with `Navigator.of(context, rootNavigator: true)`, so they sit outside Home's `Scaffold`/`bottomNavigationBar` tree and would otherwise let their last row of content sit under the gesture-navigation bar.

## Test plan

- `flutter analyze` on changed files: no new issues introduced (pre-existing lints/warnings only, unrelated to this change).
- `flutter test`: full suite green, 309 tests passed.
- Manually verified on an **Android API 36 emulator** (Pixel 7, matching our `targetSdk`) via `flutter run`:
  - Profile/home tab — bottom nav bar sits correctly above the gesture bar, status bar transparent over the dark background.
  - Settings page — "Version 3.18.0" text at the bottom is fully visible above the gesture bar, not clipped.
  - What's New page — list scrolls freely, last line not obscured.
  - Barcode page — "Add to Google Wallet" button fully visible above the gesture bar.
- **Not verified on iOS simulator** in this run: the local build failed on a missing `ios/Runner/pass_certificate.p12`, an untracked Apple Wallet signing certificate that only exists in a separate in-progress local checkout, unrelated to this change. The Dart-level fix (`SafeArea`, `SystemChrome`) is platform-agnostic and exercised by the widget test suite; a maintainer with that certificate in place should do a quick iOS pass (notch + home indicator) before merge, per the original issue's acceptance criteria.

Closes #216