### PR TITLE
chore: AGP 9 upgrade — parked, blocked on Flutter version; drop jcenter()

### DIFF
--- a/fivekmrun_app_flutter/android/build.gradle
+++ b/fivekmrun_app_flutter/android/build.gradle
@@ -1,7 +1,7 @@
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
## Summary
Investigates #217 (Play Console flags: *"Upgrade your Android Gradle plug-in to version 9.0 or higher"* for R8 optimisation). Conclusion: **the AGP 9 upgrade is blocked and parked**, per the issue's own accepted outcome for this case. One safe, unrelated cleanup item landed alongside it.

## Why it's blocked
- Current: AGP **8.6.0**, Gradle **8.7**, Flutter **3.38.3** / Dart **3.10.1** (`FLUTTER_VERSION` repo variable).
- AGP 9.0 requires **Gradle ≥ 9.1.0**, **JDK ≥ 17**, and — per Flutter's own migration notes — a minimum of **Flutter 3.44 / Dart 3.12** for supported compatibility (AGP 9 drops built-in support for applying the Kotlin Gradle Plugin the way our current setup does; Flutter's temporary shim for that only appears from 3.44 onward).
- We're two Flutter minors behind that floor. Forcing AGP 9 onto Flutter 3.38.3 would produce confusing, unsupported build failures rather than a working upgrade.
- The Flutter 3.38.3 → 3.44.8 bump itself is already tracked as its own, much larger unit of work in #222 ("Modernise the project"), which is explicitly scoped to sequence the AGP 9 bump after the Flutter bump.

**Recommendation:** park #217 until #222's Flutter upgrade lands, then re-open the AGP 9 bump as a small follow-up. Do not force it before then.

## What did land
`android/build.gradle` — replaced `jcenter()` with `mavenCentral()` in the `allprojects` repositories block. jcenter has been read-only/sunsetting since 2021; `mavenCentral()` already resolves everything in the tree. This is safe and overdue regardless of the AGP question, and was explicitly called out as such in #217's own scope notes. No other Gradle/AGP files were touched.

## Test plan
- `flutter build apk --debug` — succeeds cleanly with `mavenCentral()` in place of `jcenter()` (full dependency resolution, no missing-artifact errors).
- `flutter analyze` — clean (740 pre-existing baseline issues, unrelated to this change — there's no `analysis_options.yaml` in the repo yet, tracked separately in #222 sub-task 2).
- `flutter test` — full suite green, **309/309 passed**.
- Not run: a release AAB build or device install — out of scope, since nothing behaviourally changed (repository source swap only).

## Follow-up
- Re-attempt #217 (AGP 9 bump) once #222's Flutter 3.44.8 upgrade is merged.
- No dependency changes were made — per CLAUDE.md, I did not add or bump any package as part of this investigation.

Relates to #217, #222